### PR TITLE
A-Z support

### DIFF
--- a/dist/accessibleMenu.js
+++ b/dist/accessibleMenu.js
@@ -649,7 +649,11 @@ var AccessibleMenu = function () {
 
         this.element.addEventListener("keydown", function (event) {
           var key = event.key,
-              code = event.code;
+              code = event.code,
+              altKey = event.altKey,
+              crtlKey = event.crtlKey,
+              metaKey = event.metaKey;
+          var modifier = altKey || crtlKey || metaKey;
 
           if (_this5.currentFocus === "none") {
             if (key === "Enter" || key === " " && code === "Space") {
@@ -697,6 +701,11 @@ var AccessibleMenu = function () {
               preventDefault(event);
 
               _this5.focusLastChild();
+            } else if (key.match(/^[a-zA-Z]{1}$/) && !modifier) {
+              // The A-Z keys should focus the next menu item starting with that letter.
+              preventDefault(event);
+
+              _this5.focusNextChildWithCharacter(key);
             }
           }
 
@@ -806,6 +815,34 @@ var AccessibleMenu = function () {
       value: function focusCurrentChild() {
         if (this.focussedChild !== -1) {
           this.menuItems[this.focussedChild].focus();
+        }
+      }
+      /**
+       * Focus the menu's next child starting with a specific letter.
+       *
+       * @param {string} char - The character to look for.
+       */
+
+    }, {
+      key: "focusNextChildWithCharacter",
+      value: function focusNextChildWithCharacter(_char) {
+        // Ensure the character is lowercase just to be safe.
+        var match = _char.toLowerCase();
+
+        var index = this.focussedChild + 1;
+        var found = false;
+
+        while (!found && index < this.menuItems.length) {
+          // Ensure the text in the item is lowercase just to be safe.
+          var text = this.menuItems[index].element.innerText.toLowerCase(); // Focus the child if the text matches, otherwise move on.
+
+          if (text.startsWith(match)) {
+            found = true;
+            this.focussedChild = index;
+            this.focusCurrentChild();
+          }
+
+          index++;
         }
       }
       /**

--- a/src/menu.js
+++ b/src/menu.js
@@ -307,7 +307,8 @@ class Menu {
     }
 
     this.element.addEventListener("keydown", event => {
-      const { key, code } = event;
+      const { key, code, altKey, crtlKey, metaKey } = event;
+      const modifier = altKey || crtlKey || metaKey;
 
       if (this.currentFocus === "none") {
         if (key === "Enter" || (key === " " && code === "Space")) {
@@ -346,6 +347,10 @@ class Menu {
           // The End key should focus the last menu item.
           preventDefault(event);
           this.focusLastChild();
+        } else if (key.match(/^[a-zA-Z]{1}$/) && !modifier) {
+          // The A-Z keys should focus the next menu item starting with that letter.
+          preventDefault(event);
+          this.focusNextChildWithCharacter(key);
         }
       }
 
@@ -438,6 +443,33 @@ class Menu {
   focusCurrentChild() {
     if (this.focussedChild !== -1) {
       this.menuItems[this.focussedChild].focus();
+    }
+  }
+
+  /**
+   * Focus the menu's next child starting with a specific letter.
+   *
+   * @param {string} char - The character to look for.
+   */
+  focusNextChildWithCharacter(char) {
+    // Ensure the character is lowercase just to be safe.
+    const match = char.toLowerCase();
+
+    let index = this.focussedChild + 1;
+    let found = false;
+
+    while (!found && index < this.menuItems.length) {
+      // Ensure the text in the item is lowercase just to be safe.
+      const text = this.menuItems[index].element.innerText.toLowerCase();
+
+      // Focus the child if the text matches, otherwise move on.
+      if (text.startsWith(match)) {
+        found = true;
+        this.focussedChild = index;
+        this.focusCurrentChild();
+      }
+
+      index++;
     }
   }
 


### PR DESCRIPTION
## Description

Adding A-Z support so that hitting those keys does the following:

* Moves focus to the next menu item with a label that starts with the typed character if such an menu item exists.
* Otherwise, focus does not move

## Related Issues

Closes #8 
