### PR TITLE
refactor(menus): change methods to be protected where needed

### DIFF
--- a/docs/upgrading-from-v2-to-v3.md
+++ b/docs/upgrading-from-v2-to-v3.md
@@ -37,36 +37,48 @@ Version 3 of accessible-menu has cleaned up and renamed some class fields and me
 
 ### Menu fields
 
-- `BaseMenu.domElements` has changed to `BaseMenu._dom`
-- `BaseMenu.domSelectors` has changed to `BaseMenu._selectors`
-- `BaseMenu.menuElements` has changed to `BaseMenu._elements`
-- `BaseMenu.submenuOpenClass` has changed to `BaseMenu._openClass`
-- `BaseMenu.submenuCloseClass` has changed to `BaseMenu._closeClass`
-- `BaseMenu.root` has changed to `BaseMenu._root`
-- `BaseMenu.focussedChild` has changed to `BaseMenu._currentChild`
-- `BaseMenu.state` has changed to `BaseMenu._focusState`
-- `BaseMenu.event` has changed to `BaseMenu._currentEvent`
-- `BaseMenu.hoverable` has changed to `BaseMenu._hoverType`
-- `BaseMenu.delay` has changed to `BaseMenu._hoverDelay`
+- `BaseMenu.domElements` has been renamed to `BaseMenu._dom`
+- `BaseMenu.domSelectors` has been renamed to `BaseMenu._selectors`
+- `BaseMenu.menuElements` has been renamed to `BaseMenu._elements`
+- `BaseMenu.submenuOpenClass` has been renamed to `BaseMenu._openClass`
+- `BaseMenu.submenuCloseClass` has been renamed to `BaseMenu._closeClass`
+- `BaseMenu.root` has been renamed to `BaseMenu._root`
+- `BaseMenu.focussedChild` has been renamed to `BaseMenu._currentChild`
+- `BaseMenu.state` has been renamed to `BaseMenu._focusState`
+- `BaseMenu.event` has been renamed to `BaseMenu._currentEvent`
+- `BaseMenu.hoverable` has been renamed to `BaseMenu._hoverType`
+- `BaseMenu.delay` has been renamed to `BaseMenu._hoverDelay`
 
 ### Menu methods
 
 - `BaseMenu.setDOMElementType()` and `BaseMenu.addDOMElementType()` have been merged into `BaseMenu._setDOMEelementType()`
 - `BaseMenu.clearDOMElementType()` has been renamed to `BaseMenu._resetDOMElementType()`
 - `BaseMenu.setDOMElements()` has been renamed to `BaseMenu._setDOMElements()`
+- `BaseMenu.findRootMenu()` has been renamed to `BaseMenu._findRootMenu()`
+- `BaseMenu.createChildElements()` has been renamed to `BaseMenu._createChildElements()`
+- `BaseMenu.handleFocus()` has been renamed to `BaseMenu._handleFocus()`
+- `BaseMenu.handleClick()` has been renamed to `BaseMenu._handleClick()`
+- `BaseMenu.handleHover()` has been renamed to `BaseMenu._handleHover()`
+- `BaseMenu.handleKeydown()` has been renamed to `BaseMenu._handleKeydown()`
+- `BaseMenu.handleKeyup()` has been renamed to `BaseMenu._handleKeyup()`
 
 ### Menu item fields
 
-- `MenuItem.domElements` has changed to `BaseMenuItem._dom`
-- `MenuItem.menuElements` has changed to `BaseMenuItem._elements`
-- `MenuItem.isController` has changed to `BaseMenuItem._submenu`
+- `MenuItem.domElements` has been renamed to `BaseMenuItem._dom`
+- `MenuItem.menuElements` has been renamed to `BaseMenuItem._elements`
+- `MenuItem.isController` has been renamed to `BaseMenuItem._submenu`
 
 ### Menu toggle fields
 
-- `MenuToggle.domElements` has changed to `BaseMenuToggle._dom`
-- `MenuToggle.menuElements` has changed to `BaseMenuToggle._elements`
-- `MenuToggle.show` has changed to `BaseMenuToggle._open`
-- `MenuToggle.expandEvent` has changed to `BaseMenuToggle._expandEvent`
-- `MenuToggle.collapseEvent` has changed to `BaseMenuToggle._collapseEvent`
+- `MenuToggle.domElements` has been renamed to `BaseMenuToggle._dom`
+- `MenuToggle.menuElements` has been renamed to `BaseMenuToggle._elements`
+- `MenuToggle.show` has been renamed to `BaseMenuToggle._open`
+- `MenuToggle.expandEvent` has been renamed to `BaseMenuToggle._expandEvent`
+- `MenuToggle.collapseEvent` has been renamed to `BaseMenuToggle._collapseEvent`
 - `MenuToggle.openClass` has been removed
 - `MenuToggle.closeClass` has been removed
+
+### Menu toggle methods
+
+- `MenuToggle.expand()` has been renamed to `BaseMenuToggle._expand()`
+- `MenuToggle.collapse()` has been renamed to `BaseMenuToggle._collapse()`

--- a/src/_baseMenu.js
+++ b/src/_baseMenu.js
@@ -250,14 +250,14 @@ class BaseMenu {
    * @throws {Error} Will throw an Error if validate returns `false`.
    */
   initialize() {
-    if (!this.validate()) {
+    if (!this._validate()) {
       throw new Error(
         "AccesibleMenu: cannot initialize menu. See other error messages for more information."
       );
     }
 
     // Get the root menu if it doesn't exist.
-    if (this.elements.rootMenu === null) this.findRootMenu(this);
+    if (this.elements.rootMenu === null) this._findRootMenu(this);
 
     // Set all of the DOM elements.
     this._setDOMElements();
@@ -275,7 +275,7 @@ class BaseMenu {
       }
     }
 
-    this.createChildElements();
+    this._createChildElements();
   }
 
   /**
@@ -577,8 +577,10 @@ class BaseMenu {
    * Validates all aspects of the menu to ensure proper functionality.
    *
    * @return {boolean} - The result of the validation.
+   *
+   * @protected
    */
-  validate() {
+  _validate() {
     let check = true;
 
     if (this._dom.container !== null || this._dom.controller !== null) {
@@ -755,12 +757,14 @@ class BaseMenu {
    * Finds the root menu element.
    *
    * @param {BaseMenu} menu - The menu to check.
+   *
+   * @protected
    */
-  findRootMenu(menu) {
+  _findRootMenu(menu) {
     if (menu.isTopLevel) {
       this._elements.rootMenu = menu;
     } else if (menu.elements.parentMenu !== null) {
-      this.findRootMenu(menu.elements.parentMenu);
+      this._findRootMenu(menu.elements.parentMenu);
     } else {
       throw new Error("Cannot find root menu.");
     }
@@ -768,8 +772,10 @@ class BaseMenu {
 
   /**
    * Creates and initializes all menu items and submenus.
+   *
+   * @protected
    */
-  createChildElements() {
+  _createChildElements() {
     this.dom.menuItems.forEach((element) => {
       let menuItem;
 
@@ -836,8 +842,10 @@ class BaseMenu {
    * - Adds a `focus` listener to every menu item so when it gains focus,
    *   it will set the item's containing menu's {@link BaseMenu#focusState|focus state}
    *   to "self".
+   *
+   * @protected
    */
-  handleFocus() {
+  _handleFocus() {
     this.elements.menuItems.forEach((menuItem, index) => {
       menuItem.dom.link.addEventListener("focus", () => {
         this.focusState = "self";
@@ -862,8 +870,10 @@ class BaseMenu {
    * - Adds a `touchend`/`mouseup` listener to the menu's controller
    *   (if the menu is the root menu) so when it is clicked it will properly
    *   toggle open/closed.
+   *
+   * @protected
    */
-  handleClick() {
+  _handleClick() {
     // Use touch over mouse events when supported.
     const startEventType = isEventSupported("touchstart", this.dom.menu)
       ? "touchstart"
@@ -953,8 +963,10 @@ class BaseMenu {
    *
    * **Hover Type "off"**
    * All `mouseenter` and `mouseleave` events are ignored.
+   *
+   * @protected
    */
-  handleHover() {
+  _handleHover() {
     this.elements.menuItems.forEach((menuItem, index) => {
       menuItem.dom.link.addEventListener("mouseenter", () => {
         if (this.hoverType === "on") {
@@ -1017,12 +1029,14 @@ class BaseMenu {
   /**
    * Handles keydown events throughout the menu for proper menu use.
    *
-   * This method exists to assit the {@link BaseMenu#handleKeyup|handleKeyup method}.
+   * This method exists to assit the {@link BaseMenu#_handleKeyup|_handleKeyup method}.
    *
    * - Adds a `keydown` listener to the menu's controller (if the menu is the root menu).
    *   - Blocks propagation on "Space", "Enter", and "Escape" keys.
+   *
+   * @protected
    */
-  handleKeydown() {
+  _handleKeydown() {
     if (this.isTopLevel && this.elements.controller) {
       this.elements.controller.dom.toggle.addEventListener(
         "keydown",
@@ -1044,8 +1058,10 @@ class BaseMenu {
    *
    * - Adds a `keyup` listener to the menu's controller (if the menu is the root menu).
    *   - Opens the menu when the user hits "Space" or "Enter".
+   *
+   * @protected
    */
-  handleKeyup() {
+  _handleKeyup() {
     if (this.isTopLevel && this.elements.controller) {
       this.elements.controller.dom.toggle.addEventListener("keyup", (event) => {
         this.currentEvent = "keyboard";

--- a/src/_baseMenuToggle.js
+++ b/src/_baseMenuToggle.js
@@ -175,7 +175,7 @@ class BaseMenuToggle {
     );
 
     // Make sure the menu is collapsed on initialization, but do not emit the collapse event.
-    this.collapse(false);
+    this._collapse(false);
   }
 
   /**
@@ -229,8 +229,10 @@ class BaseMenuToggle {
    *
    * @param {boolean} [emit = true] - A toggle to emit the expand event once expanded.
    * @fires accessibleMenuExpand
+   *
+   * @protected
    */
-  expand(emit = true) {
+  _expand(emit = true) {
     const { closeClass, openClass } = this.elements.controlledMenu;
 
     this.dom.toggle.setAttribute("aria-expanded", "true");
@@ -271,8 +273,10 @@ class BaseMenuToggle {
    *
    * @param {boolean} [emit = true] - A toggle to emit the collapse event once collapsed.
    * @fires accessibleMenuCollapse
+   *
+   * @protected
    */
-  collapse(emit = true) {
+  _collapse(emit = true) {
     const { closeClass, openClass } = this.elements.controlledMenu;
 
     this.dom.toggle.setAttribute("aria-expanded", "false");
@@ -312,7 +316,7 @@ class BaseMenuToggle {
     this.elements.controlledMenu.focusState = "self";
 
     // Expand the controlled menu.
-    this.expand();
+    this._expand();
 
     // Set the open flag.
     this.isOpen = true;
@@ -332,7 +336,7 @@ class BaseMenuToggle {
     }
 
     // Expand the controlled menu.
-    this.expand();
+    this._expand();
 
     // Set the open flag.
     this.isOpen = true;
@@ -359,7 +363,7 @@ class BaseMenuToggle {
       }
 
       // Collapse the controlled menu.
-      this.collapse();
+      this._collapse();
 
       // Set the open flag.
       this.isOpen = false;

--- a/src/disclosureMenu.js
+++ b/src/disclosureMenu.js
@@ -129,6 +129,33 @@ class DisclosureMenu extends BaseMenu {
   }
 
   /**
+   * Initializes the menu.
+   *
+   * Initialize will call the {@link BaseMenu#initialize|BaseMenu's initialize method}
+   * as well as set up {@link DisclosureMenu#_handleFocus|focus},
+   * {@link DisclosureMenu#_handleClick|click},
+   * {@link DisclosureMenu#_handleHover|hover},
+   * {@link DisclosureMenu#_handleKeydown|keydown}, and
+   * {@link DisclosureMenu#_handleKeyup|keyup} events for the menu.
+   *
+   * If the BaseMenu's initialize method throws an error,
+   * this will catch it and log it to the console.
+   */
+  initialize() {
+    try {
+      super.initialize();
+
+      this._handleFocus();
+      this._handleClick();
+      this._handleHover();
+      this._handleKeydown();
+      this._handleKeyup();
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  /**
    * A flag to add optional keyboard support (Arrow keys, "Home", and "End") to the menu.
    *
    * This functions differently for root vs. submenus.
@@ -150,39 +177,14 @@ class DisclosureMenu extends BaseMenu {
   }
 
   /**
-   * Initializes the menu.
-   *
-   * Initialize will call the {@link BaseMenu#initialize|BaseMenu's initialize method}
-   * as well as set up {@link DisclosureMenu#handleFocus|focus},
-   * {@link DisclosureMenu#handleClick|click},
-   * {@link DisclosureMenu#handleHover|hover},
-   * {@link DisclosureMenu#handleKeydown|keydown}, and
-   * {@link DisclosureMenu#handleKeyup|keyup} events for the menu.
-   *
-   * If the BaseMenu's initialize method throws an error,
-   * this will catch it and log it to the console.
-   */
-  initialize() {
-    try {
-      super.initialize();
-
-      this.handleFocus();
-      this.handleClick();
-      this.handleHover();
-      this.handleKeydown();
-      this.handleKeyup();
-    } catch (error) {
-      console.error(error);
-    }
-  }
-
-  /**
    * Validates all aspects of the menu to ensure proper functionality.
    *
    * @return {boolean} - The result of the validation.
+   *
+   * @protected
    */
-  validate() {
-    let check = super.validate();
+  _validate() {
+    let check = super._validate();
 
     if (
       !isValidType("boolean", { optionalKeySupport: this._optionalSupport })
@@ -200,13 +202,14 @@ class DisclosureMenu extends BaseMenu {
    * `mousedown` and `mouseup` will be used for all "click" event handling.
    *
    * - Adds all event listeners listed in
-   *   {@link BaseMenu#handleClick|BaseMenu's handleClick method}, and
+   *   {@link BaseMenu#_handleClick|BaseMenu's _handleClick method}, and
    * - adds a `touchend`/`mouseup` listener to the `document` so if the user
    *   clicks outside of the menu it will close if it is open.
    *
+   * @protected
    */
-  handleClick() {
-    super.handleClick();
+  _handleClick() {
+    super._handleClick();
 
     // Use touch over mouse events when supported.
     const endEventType = isEventSupported("touchend", this.dom.menu)
@@ -236,16 +239,18 @@ class DisclosureMenu extends BaseMenu {
   /**
    * Handles keydown events throughout the menu for proper menu use.
    *
-   * This method exists to assist the {@link DisclosureMenu#handleKeyup|handleKeyup method}.
-   * - Adds all `keydown` listeners from {@link BaseMenu#handleKeydown|BaseMenu's handleKeydown method}
+   * This method exists to assist the {@link DisclosureMenu#_handleKeyup|_handleKeyup method}.
+   * - Adds all `keydown` listeners from {@link BaseMenu#_handleKeydown|BaseMenu's _handleKeydown method}
    * - Adds a `keydown` listener to the menu/all submenus.
    *   - Blocks propagation on the following keys: "Space", "Enter", and "Escape".
    *   - _If_ {@link DisclosureMenu#optionalKeySupport|optional keyboard support}
    *     is enabled, blocks propagation on the following keys:
    *     "ArrowUp", "ArrowRight", "ArrowDown", "ArrowLeft", "Home", and "End".
+   *
+   * @protected
    */
-  handleKeydown() {
-    super.handleKeydown();
+  _handleKeydown() {
+    super._handleKeydown();
 
     this.dom.menu.addEventListener("keydown", (event) => {
       this.currentEvent = "keyboard";
@@ -287,7 +292,7 @@ class DisclosureMenu extends BaseMenu {
   /**
    * Handles keyup events throughout the menu for proper menu use.
    *
-   * Adds all `keyup` listeners from {@link BaseMenu#handleKeyup|BaseMenu's handleKeyup method}.
+   * Adds all `keyup` listeners from {@link BaseMenu#_handleKeyup|BaseMenu's _handleKeyup method}.
    *
    * Adds the following keybindings (explanations are taken from the
    * {@link https://www.w3.org/TR/wai-aria-practices-1.2/examples/disclosure/disclosure-navigation.html#kbd_label|WAI ARIA Pracitices Example Disclosure for Navigation Menus}):
@@ -303,9 +308,11 @@ class DisclosureMenu extends BaseMenu {
    * | _End_ (Optional}) | <ul><li>If focus is on a button, and it is not the last button, moves focus to the last button.</li><li>If focus is on a link, and it is not the last link, moves focus to the last link.</li></ul> |
    *
    * The optional keybindings are controlled by the menu's {@link DisclosureMenu#optionalKeySupport|optionalKeySupport} value.
+   *
+   * @protected
    */
-  handleKeyup() {
-    super.handleKeyup();
+  _handleKeyup() {
+    super._handleKeyup();
 
     this.dom.menu.addEventListener("keyup", (event) => {
       this.currentEvent = "keyboard";

--- a/src/menubar.js
+++ b/src/menubar.js
@@ -111,11 +111,11 @@ class Menubar extends BaseMenu {
    * Initializes the menu.
    *
    * Initialize will call the {@link BaseMenu#initialize|BaseMenu's initialize method}
-   * as well as set up {@link Menubar#handleFocus|focus},
-   * {@link Menubar#handleClick|click},
-   * {@link Menubar#handleHover|hover},
-   * {@link Menubar#handleKeydown|keydown}, and
-   * {@link Menubar#handleKeyup|keyup} events for the menu.
+   * as well as set up {@link Menubar#_handleFocus|focus},
+   * {@link Menubar#_handleClick|click},
+   * {@link Menubar#_handleHover|hover},
+   * {@link Menubar#_handleKeydown|keydown}, and
+   * {@link Menubar#_handleKeyup|keyup} events for the menu.
    *
    * This will also set the menu's `role` to "menubar" in the DOM.
    *
@@ -131,11 +131,11 @@ class Menubar extends BaseMenu {
 
       this.dom.menu.setAttribute("role", "menubar");
 
-      this.handleFocus();
-      this.handleClick();
-      this.handleHover();
-      this.handleKeydown();
-      this.handleKeyup();
+      this._handleFocus();
+      this._handleClick();
+      this._handleHover();
+      this._handleKeydown();
+      this._handleKeyup();
 
       if (this.isTopLevel) {
         this.elements.menuItems[0].dom.link.tabIndex = 0;
@@ -152,12 +152,14 @@ class Menubar extends BaseMenu {
    * `mousedown` and `mouseup` will be used for all "click" event handling.
    *
    * - Adds all event listeners listed in
-   *   {@link BaseMenu#handleClick|BaseMenu's handleClick method}, and
+   *   {@link BaseMenu#_handleClick|BaseMenu's _handleClick method}, and
    * - adds a `touchend`/`mouseup` listener to the `document` so if the user
    *   clicks outside of the menu it will close if it is open.
+   *
+   * @protected
    */
-  handleClick() {
-    super.handleClick();
+  _handleClick() {
+    super._handleClick();
 
     // Use touch over mouse events when supported.
     const endEventType = isEventSupported("touchend", this.dom.menu)
@@ -187,16 +189,18 @@ class Menubar extends BaseMenu {
   /**
    * Handles keydown events throughout the menu for proper menu use.
    *
-   * This method exists to assist the {@link Menubar#handleKeyup|handleKeyup method}.
-   * - Adds all `keydown` listeners from {@link BaseMenu#handleKeydown|BaseMenu's handleKeydown method}
+   * This method exists to assist the {@link Menubar#_handleKeyup|_handleKeyup method}.
+   * - Adds all `keydown` listeners from {@link BaseMenu#_handleKeydown|BaseMenu's _handleKeydown method}
    * - Adds a `keydown` listener to the menu/all submenus.
    *   - Blocks propagation on the following keys: "ArrowUp", "ArrowRight",
    *     "ArrowDown", "ArrowLeft", "Home", "End", "Space", "Enter", "Escape",
    *     and "A" through "Z".
    *   - Completely closes the menu and moves focus out if the "Tab" key is pressed.
+   *
+   * @protected
    */
-  handleKeydown() {
-    super.handleKeydown();
+  _handleKeydown() {
+    super._handleKeydown();
 
     this.dom.menu.addEventListener("keydown", (event) => {
       this.currentEvent = "keyboard";
@@ -261,7 +265,7 @@ class Menubar extends BaseMenu {
   /**
    * Handles keyup events throughout the menu for proper menu use.
    *
-   * Adds all `keyup` listeners from {@link BaseMenu#handleKeyup|BaseMenu's handleKeyup method}.
+   * Adds all `keyup` listeners from {@link BaseMenu#_handleKeyup|BaseMenu's _handleKeyup method}.
    *
    * Adds the following keybindings (explanations are taken from the
    * {@link https://www.w3.org/TR/2019/WD-wai-aria-practices-1.2-20191218/examples/menubar/menubar-1/menubar-1.html#kbd_label|Navigation Menubar Example}):
@@ -292,9 +296,11 @@ class Menubar extends BaseMenu {
    * | Home | Moves focus to the first item in the submenu. |
    * | End | Moves focus to the last item in the submenu. |
    * | _Character_ | <ul><li>Moves focus to the next item having a name that starts with the typed character.</li><li>If none of the items have a name starting with the typed character, focus does not move.</li></ul> |
+   *
+   * @protected
    */
-  handleKeyup() {
-    super.handleKeyup();
+  _handleKeyup() {
+    super._handleKeyup();
 
     this.dom.menu.addEventListener("keyup", (event) => {
       this.currentEvent = "keyboard";

--- a/src/treeview.js
+++ b/src/treeview.js
@@ -110,11 +110,11 @@ class Treeview extends BaseMenu {
    * Initializes the menu.
    *
    * Initialize will call the {@link BaseMenu#initialize|BaseMenu's initialize method}
-   * as well as set up {@link Treeview#handleFocus|focus},
-   * {@link Treeview#handleClick|click},
-   * {@link Treeview#handleHover|hover},
-   * {@link Treeview#handleKeydown|keydown}, and
-   * {@link Treeview#handleKeyup|keyup} events for the menu.
+   * as well as set up {@link Treeview#_handleFocus|focus},
+   * {@link Treeview#_handleClick|click},
+   * {@link Treeview#_handleHover|hover},
+   * {@link Treeview#_handleKeydown|keydown}, and
+   * {@link Treeview#_handleKeyup|keyup} events for the menu.
    *
    * If the menu is a root menu it's `role` will be set to "tree" and the first
    * menu item's `tabIndex` will be set to 0 in the DOM.
@@ -135,11 +135,11 @@ class Treeview extends BaseMenu {
         this.dom.menu.setAttribute("role", "group");
       }
 
-      this.handleFocus();
-      this.handleClick();
-      this.handleHover();
-      this.handleKeydown();
-      this.handleKeyup();
+      this._handleFocus();
+      this._handleClick();
+      this._handleHover();
+      this._handleKeydown();
+      this._handleKeyup();
     } catch (error) {
       console.error(error);
     }
@@ -148,16 +148,18 @@ class Treeview extends BaseMenu {
   /**
    * Handles keydown events throughout the menu for proper menu use.
    *
-   * This method exists to assist the {@link Treeview#handleKeyup|handleKeyup method}.
-   * - Adds all `keydown` listeners from {@link BaseMenu#handleKeydown|BaseMenu's handleKeydown method}
+   * This method exists to assist the {@link Treeview#_handleKeyup|_handleKeyup method}.
+   * - Adds all `keydown` listeners from {@link BaseMenu#_handleKeydown|BaseMenu's _handleKeydown method}
    * - Adds a `keydown` listener to the menu/all submenus.
    *   - Blocks propagation on the following keys: "ArrowUp", "ArrowRight",
    *     "ArrowDown", "ArrowLeft", "Home", "End", "Space", "Enter", "Escape",
    *     "*" (asterisk), and "A" through "Z".
    *   - Moves focus out if the "Tab" key is pressed.
+   *
+   * @protected
    */
-  handleKeydown() {
-    super.handleKeydown();
+  _handleKeydown() {
+    super._handleKeydown();
 
     this.dom.menu.addEventListener("keydown", (event) => {
       this.currentEvent = "keyboard";
@@ -204,7 +206,7 @@ class Treeview extends BaseMenu {
   /**
    * Handles keyup events throughout the menu for proper menu use.
    *
-   * Adds all `keyup` listeners from {@link BaseMenu#handleKeyup|BaseMenu's handleKeyup method}.
+   * Adds all `keyup` listeners from {@link BaseMenu#_handleKeyup|BaseMenu's _handleKeyup method}.
    *
    * Adds the following keybindings (explanations are taken from the
    * {@link https://www.w3.org/TR/2019/WD-wai-aria-practices-1.2-20191218/examples/treeview/treeview-2/treeview-2a.html#kbd_label|Navigation Treeview Example Using Computed Properties}):
@@ -221,9 +223,11 @@ class Treeview extends BaseMenu {
    * | _a-z_, _A-Z_ | <ul><li>Focus moves to the next node with a name that starts with the typed character.</li><li>Search wraps to first node if a matching name is not found among the nodes that follow the focused node.</li><li>Search ignores nodes that are descendants of closed nodes.</li></ul> |
    * | _* (asterisk)_ | <ul><li>Expands all closed sibling nodes that are at the same level as the focused node.</li><li>Focus does not move.</li></ul> |
    * | _Escape_ | If the root menu is collapsible, collapses the menu and focuses the menu's controlling element. |
+   *
+   * @protected
    */
-  handleKeyup() {
-    super.handleKeyup();
+  _handleKeyup() {
+    super._handleKeyup();
 
     this.dom.menu.addEventListener("keyup", (event) => {
       this.currentEvent = "keyboard";


### PR DESCRIPTION
BREAKING CHANGE: changed the name of all menu event handler methods and toggle expand/collapse
methods to begin with _
