### PR TITLE
docs(examples): use proper links to api in basic examples

### DIFF
--- a/docs/basics/single-level-menu-with-toggle.md
+++ b/docs/basics/single-level-menu-with-toggle.md
@@ -28,7 +28,7 @@ Given the above structure, the parameters needed for an accessible menu are:
 - `containerElement`
 - `openClass`
 
-Depending on what kind of menu you'd like to create you can either use [Menubar](../classes/Menubar.md) or [DisclosureMenu](../classes/DisclosureMenu.md).
+Depending on what kind of menu you'd like to create you can use [DisclosureMenu](https://accessible-menu.netlify.app/disclosuremenu), [Menubar](https://accessible-menu.netlify.app/menubar), or [Treeview](https://accessible-menu.netlify.app/treeview).
 
 ```js
 const menu = new AccessibleMenu.DisclosureMenu({

--- a/docs/basics/single-level-menu.md
+++ b/docs/basics/single-level-menu.md
@@ -24,7 +24,7 @@ Given the above structure, the parameters needed for an accessible menu are:
 
 - `menuElement`
 
-Depending on what kind of menu you'd like to create you can either use [Menubar](../classes/Menubar.md) or [DisclosureMenu](../classes/DisclosureMenu.md).
+Depending on what kind of menu you'd like to create you can use [DisclosureMenu](https://accessible-menu.netlify.app/disclosuremenu), [Menubar](https://accessible-menu.netlify.app/menubar), or [Treeview](https://accessible-menu.netlify.app/treeview).
 
 ```js
 const menu = new AccessibleMenu.DisclosureMenu({

--- a/docs/basics/two-level-menu-with-toggle.md
+++ b/docs/basics/two-level-menu-with-toggle.md
@@ -37,7 +37,7 @@ Given the above structure, the parameters needed for an accessible menu are:
 - `containerElement`
 - `openClass`
 
-Depending on what kind of menu you'd like to create you can either use [Menubar](../classes/Menubar.md) or [DisclosureMenu](../classes/DisclosureMenu.md).
+Depending on what kind of menu you'd like to create you can use [DisclosureMenu](https://accessible-menu.netlify.app/disclosuremenu), [Menubar](https://accessible-menu.netlify.app/menubar), or [Treeview](https://accessible-menu.netlify.app/treeview).
 
 ```js
 const menu = new AccessibleMenu.DisclosureMenu({


### PR DESCRIPTION
## Description
Links to menus were out-of-date and broken
