### PR TITLE
Remove remaining mouseevents

### DIFF
--- a/src/_baseMenu.js
+++ b/src/_baseMenu.js
@@ -996,7 +996,7 @@ class BaseMenu {
    */
   _handleHover() {
     this.elements.menuItems.forEach((menuItem, index) => {
-      menuItem.dom.link.addEventListener("mouseenter", () => {
+      menuItem.dom.link.addEventListener("pointerenter", () => {
         if (this.hoverType === "on") {
           this.currentEvent = "mouse";
           this.currentChild = index;
@@ -1023,7 +1023,7 @@ class BaseMenu {
       });
 
       if (menuItem.isSubmenuItem) {
-        menuItem.dom.item.addEventListener("mouseleave", () => {
+        menuItem.dom.item.addEventListener("pointerleave", () => {
           if (this.hoverType === "on") {
             if (this.hoverDelay > 0) {
               setTimeout(() => {

--- a/tests/menus/_common/functional.js
+++ b/tests/menus/_common/functional.js
@@ -7,8 +7,8 @@
 
 import { twoLevelMenu, fullMenu } from "./test-menus";
 import {
-  simulateClick,
-  simulateMouseEvent,
+  simulatePointer,
+  simulatePointerEvent,
   simulateKeypress,
   toggleIsOpen,
   toggleIsClosed,
@@ -117,7 +117,7 @@ export function clickTests(MenuClass) {
       controller.close();
 
       // Simulate the click.
-      simulateClick(controller.dom.toggle);
+      simulatePointer(controller.dom.toggle);
 
       // Toggle expectations.
       expect(controller.isOpen).toBeTrue();
@@ -144,7 +144,7 @@ export function clickTests(MenuClass) {
       controller.open();
 
       // Simulate the click.
-      simulateClick(controller.dom.toggle);
+      simulatePointer(controller.dom.toggle);
 
       toggleIsClosed(controller);
     });
@@ -165,7 +165,7 @@ export function clickTests(MenuClass) {
         controller.open();
 
         // Simulate the click.
-        simulateClick(document.querySelector("main"));
+        simulatePointer(document.querySelector("main"));
 
         toggleIsClosed(controller);
       });
@@ -181,7 +181,7 @@ export function clickTests(MenuClass) {
       const toggle = menu.elements.submenuToggles[0];
 
       // Simulate the click.
-      simulateClick(toggle.dom.toggle);
+      simulatePointer(toggle.dom.toggle);
 
       toggleIsPreviewed(toggle);
     });
@@ -200,7 +200,7 @@ export function clickTests(MenuClass) {
       toggle.open();
 
       // Simulate the click.
-      simulateClick(toggle.dom.toggle);
+      simulatePointer(toggle.dom.toggle);
 
       toggleIsClosed(toggle);
     });
@@ -228,7 +228,7 @@ export function hoverTests(MenuClass) {
       const toggle = menu.elements.submenuToggles[0];
 
       // Simulate the mouse.
-      simulateMouseEvent("mouseenter", toggle.dom.toggle);
+      simulatePointerEvent("pointerenter", toggle.dom.toggle);
 
       toggleIsPreviewed(toggle);
     });
@@ -249,7 +249,7 @@ export function hoverTests(MenuClass) {
       toggle.open();
 
       // Simulate the mouse.
-      simulateMouseEvent("mouseleave", menuItem.dom.item);
+      simulatePointerEvent("pointerleave", menuItem.dom.item);
 
       toggleIsClosed(toggle);
     });
@@ -271,7 +271,7 @@ export function hoverTests(MenuClass) {
       menu.elements.menuItems[0].dom.link.focus();
 
       // Simulate the mouse.
-      simulateMouseEvent("mouseenter", toggle.dom.toggle);
+      simulatePointerEvent("pointerenter", toggle.dom.toggle);
 
       toggleIsClosed(toggle);
     });
@@ -292,7 +292,7 @@ export function hoverTests(MenuClass) {
       toggle.open();
 
       // Simulate the mouse.
-      simulateMouseEvent("mouseleave", menuItem.dom.item);
+      simulatePointerEvent("pointerleave", menuItem.dom.item);
 
       toggleIsOpen(toggle);
     });
@@ -318,7 +318,7 @@ export function hoverTests(MenuClass) {
       originalToggle.open();
 
       // Simulate the mouse.
-      simulateMouseEvent("mouseenter", newToggle.dom.toggle);
+      simulatePointerEvent("pointerenter", newToggle.dom.toggle);
 
       if (menuType === "DisclosureMenu" || menuType === "Menubar") {
         toggleIsClosed(originalToggle);
@@ -348,7 +348,7 @@ export function hoverTests(MenuClass) {
       toggle.open();
 
       // Simulate the mouse.
-      simulateMouseEvent("mouseenter", submenuToggle.dom.toggle);
+      simulatePointerEvent("pointerenter", submenuToggle.dom.toggle);
 
       toggleIsPreviewed(submenuToggle);
     });
@@ -377,7 +377,7 @@ export function hoverTests(MenuClass) {
       submenuToggle.open();
 
       // Simulate the mouse.
-      simulateMouseEvent("mouseleave", submenuItem.dom.item);
+      simulatePointerEvent("pointerleave", submenuItem.dom.item);
 
       toggleIsClosed(submenuToggle);
     });

--- a/tests/menus/_common/helpers.js
+++ b/tests/menus/_common/helpers.js
@@ -18,48 +18,6 @@ class PointerEvent extends window.MouseEvent {
 window.PointerEvent = PointerEvent;
 
 /**
- * Simulates a mouse event on a DOM element.
- *
- * @param {string}      eventType - The type of event to trigger.
- * @param {HTMLElement} element   - The element to trigger the event on.
- * @param {object}      options   - Custom options for the event.
- */
-export function simulateMouseEvent(eventType, element, options = {}) {
-  try {
-    const event = new MouseEvent(eventType, {
-      view: window,
-      bubbles: true,
-      cancelable: true,
-      ...options,
-    });
-    element.dispatchEvent(event);
-  } catch (error) {
-    console.error(error);
-  }
-}
-
-/**
- * Simulates a touch event on a DOM element.
- *
- * @param {string}      eventType - The type of event to trigger.
- * @param {HTMLElement} element   - The element to trigger the event on.
- * @param {object}      options   - Custom options for the event.
- */
-export function simulateTouchEvent(eventType, element, options = {}) {
-  try {
-    const event = new TouchEvent(eventType, {
-      view: window,
-      bubbles: true,
-      cancelable: true,
-      ...options,
-    });
-    element.dispatchEvent(event);
-  } catch (error) {
-    console.error(error);
-  }
-}
-
-/**
  * Simulates a pointer event on a DOM element.
  *
  * @param {string}      eventType - The type of event to trigger.
@@ -102,25 +60,14 @@ export function simulateKeyboardEvent(eventType, element, options = {}) {
 }
 
 /**
- * Simulates a pointerdown and a pointerup event on a DOM element.
+ * Simulates a pointerdown and pointerup event on a DOM element.
  *
  * @param {HTMLElement} element - The element to trigger the events on.
  * @param {object}      options - Custom options for the events.
  */
-export function simulateClick(element, options = {}) {
+export function simulatePointer(element, options = {}) {
   simulatePointerEvent("pointerdown", element, options);
   simulatePointerEvent("pointerup", element, options);
-}
-
-/**
- * Simulates a touchstart and touchend event on a DOM element.
- *
- * @param {HTMLElement} element - The element to trigger the events on.
- * @param {object}      options - Custom options for the events.
- */
-export function simulateTap(element, options = {}) {
-  simulateTouchEvent("touchstart", element, options);
-  simulateTouchEvent("touchend", element, options);
 }
 
 /**


### PR DESCRIPTION
## Description
Mouse/touch events were replaced in `_handleClick()`. `_handleHover()` should follow suit.
