### PR TITLE
fix(menu): only trigger hover events if pointerType is mouse

### DIFF
--- a/src/_baseMenu.js
+++ b/src/_baseMenu.js
@@ -961,8 +961,8 @@ class BaseMenu {
    * to all submenu items which function differently depending on
    * the menu's {@link BaseMenu_hoverTypeType|hover type}.
    *
-   * Before executing anything, the event is checked to make sure the event was
-   * triggered by a mouse- not a pen or touch.
+   * Before executing anything, the event is checked to make sure the event wasn't
+   * triggered by a pen or touch.
    *
    * <strong>Hover Type "on"</strong>
    * - When a `pointerenter` event triggers on any menu item the menu's
@@ -1001,7 +1001,8 @@ class BaseMenu {
     this.elements.menuItems.forEach((menuItem, index) => {
       menuItem.dom.link.addEventListener("pointerenter", (event) => {
         // Exit out of the event if it was not made by a mouse.
-        if (event.pointerType !== "mouse") return;
+        if (event.pointerType === "pen" || event.pointerType === "touch")
+          return;
 
         if (this.hoverType === "on") {
           this.currentEvent = "mouse";
@@ -1031,7 +1032,8 @@ class BaseMenu {
       if (menuItem.isSubmenuItem) {
         menuItem.dom.item.addEventListener("pointerleave", (event) => {
           // Exit out of the event if it was not made by a mouse.
-          if (event.pointerType !== "mouse") return;
+          if (event.pointerType === "pen" || event.pointerType === "touch")
+            return;
 
           if (this.hoverType === "on") {
             if (this.hoverDelay > 0) {

--- a/src/_baseMenu.js
+++ b/src/_baseMenu.js
@@ -1001,9 +1001,9 @@ class BaseMenu {
     this.elements.menuItems.forEach((menuItem, index) => {
       menuItem.dom.link.addEventListener("pointerenter", (event) => {
         // Exit out of the event if it was not made by a mouse.
-        if (event.pointerType === "pen" || event.pointerType === "touch")
+        if (event.pointerType === "pen" || event.pointerType === "touch") {
           return;
-
+        }
         if (this.hoverType === "on") {
           this.currentEvent = "mouse";
           this.currentChild = index;
@@ -1032,8 +1032,9 @@ class BaseMenu {
       if (menuItem.isSubmenuItem) {
         menuItem.dom.item.addEventListener("pointerleave", (event) => {
           // Exit out of the event if it was not made by a mouse.
-          if (event.pointerType === "pen" || event.pointerType === "touch")
+          if (event.pointerType === "pen" || event.pointerType === "touch") {
             return;
+          }
 
           if (this.hoverType === "on") {
             if (this.hoverDelay > 0) {

--- a/src/_baseMenu.js
+++ b/src/_baseMenu.js
@@ -1004,6 +1004,7 @@ class BaseMenu {
         if (event.pointerType === "pen" || event.pointerType === "touch") {
           return;
         }
+
         if (this.hoverType === "on") {
           this.currentEvent = "mouse";
           this.currentChild = index;

--- a/src/_baseMenu.js
+++ b/src/_baseMenu.js
@@ -957,46 +957,52 @@ class BaseMenu {
   /**
    * Handles hover events throughout the menu for proper use.
    *
-   * Adds `mouseenter` listeners to all menu items and `mouseleave` listeners
+   * Adds `pointerenter` listeners to all menu items and `pointerleave` listeners
    * to all submenu items which function differently depending on
    * the menu's {@link BaseMenu_hoverTypeType|hover type}.
    *
+   * Before executing anything, the event is checked to make sure the event was
+   * triggered by a mouse- not a pen or touch.
+   *
    * <strong>Hover Type "on"</strong>
-   * - When a `mouseenter` event triggers on any menu item the menu's
+   * - When a `pointerenter` event triggers on any menu item the menu's
    *   {@link BaseMenu#currentChild| current child} value will change to that
    *   menu item.
-   * - When a `mouseenter` event triggers on a submenu item the
+   * - When a `pointerenter` event triggers on a submenu item the
    *   {@link BaseMenuToggle#preview|preview method} for the submenu item's
    *   toggle will be called.
-   * - When a `mouseleave` event triggers on an open submenu item the
+   * - When a `pointerleave` event triggers on an open submenu item the
    *   {@link BaseMenuToggle#close|close method} for the submenu item's toggle
    *   will be called after a delay set by the menu's {@link BaseMenu_hoverTypeDelay|hover delay}.
    *
    * <strong>Hover Type "dynamic"</strong>
-   * - When a `mouseenter` event triggers on any menu item the menu's
+   * - When a `pointerenter` event triggers on any menu item the menu's
    *   current child value will change to that menu item.
-   * - When a `mouseenter` event triggers on any menu item, and the menu's
+   * - When a `pointerenter` event triggers on any menu item, and the menu's
    *   {@link BaseMenu#focusState|focus state} is not "none", the menu item
    *   will be focused.
-   * - When a `mouseenter` event triggers on a submenu item, and a submenu is
+   * - When a `pointerenter` event triggers on a submenu item, and a submenu is
    *   already open, the preview method for the submenu item's toggle will be called.
-   * - When a `mouseenter` event triggers on a submenu item, and no submenu is
+   * - When a `pointerenter` event triggers on a submenu item, and no submenu is
    *   open, no submenu-specific methods will be called.
-   * - When a `mouseleave` event triggers on an open submenu item that is not a
+   * - When a `pointerleave` event triggers on an open submenu item that is not a
    *   root-level submenu item the close method for the submenu item's toggle
    *   will be called and the submenu item will be focused after a delay set by
    *   the menu's hover delay.
-   * - When a `mouseleave` event triggers on an open submenu item that is a
+   * - When a `pointerleave` event triggers on an open submenu item that is a
    *   root-level submenu item no submenu-specific methods will be called.
    *
    * <strong>Hover Type "off"</strong>
-   * All `mouseenter` and `mouseleave` events are ignored.
+   * All `pointerenter` and `pointerleave` events are ignored.
    *
    * @protected
    */
   _handleHover() {
     this.elements.menuItems.forEach((menuItem, index) => {
-      menuItem.dom.link.addEventListener("pointerenter", () => {
+      menuItem.dom.link.addEventListener("pointerenter", (event) => {
+        // Exit out of the event if it was not made by a mouse.
+        if (event.pointerType !== "mouse") return;
+
         if (this.hoverType === "on") {
           this.currentEvent = "mouse";
           this.currentChild = index;
@@ -1023,7 +1029,10 @@ class BaseMenu {
       });
 
       if (menuItem.isSubmenuItem) {
-        menuItem.dom.item.addEventListener("pointerleave", () => {
+        menuItem.dom.item.addEventListener("pointerleave", (event) => {
+          // Exit out of the event if it was not made by a mouse.
+          if (event.pointerType !== "mouse") return;
+
           if (this.hoverType === "on") {
             if (this.hoverDelay > 0) {
               setTimeout(() => {


### PR DESCRIPTION
## Description

I introduced a bug when changing the hover stuff to pointer events. I didn't realize pointerenter uses pointerdown when hover isn't supported.

This will not make sure the pointer event type is mouse before doing anything with hover.
