### PR TITLE
test(environment): use jsdom globally

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   setupFilesAfterEnv: ["jest-extended/all"],
-  testEnvironment: "jest-environment-jsdom-latest",
+  testEnvironment: "jsdom",
 };

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "eslint-plugin-promise": "^5.1.0",
     "husky": "^7.0.2",
     "jest": "^27.0.4",
-    "jest-environment-jsdom-latest": "^26.6.2",
     "jest-extended": "^1.0.0",
     "jsdoc": "^3.6.7",
     "jsdoc-typeof-plugin": "^1.0.0",

--- a/tests/menus/DisclosureMenu/aria.test.js
+++ b/tests/menus/DisclosureMenu/aria.test.js
@@ -1,7 +1,5 @@
 /**
  * Test the DisclosureMenu class for proper ARIA attributes.
- *
- * @jest-environment jsdom
  */
 
 import { DisclosureMenu } from "../../../index";

--- a/tests/menus/DisclosureMenu/functional.test.js
+++ b/tests/menus/DisclosureMenu/functional.test.js
@@ -1,7 +1,5 @@
 /**
  * Test the DisclosureMenu class to make sure it functions correctly.
- *
- * @jest-environment jsdom
  */
 
 import { DisclosureMenu } from "../../../index";

--- a/tests/menus/DisclosureMenu/initialization.test.js
+++ b/tests/menus/DisclosureMenu/initialization.test.js
@@ -1,7 +1,5 @@
 /**
  * Test the DisclosureMenu class to make sure it can initialize under various scenarios.
- *
- * @jest-environment jsdom
  */
 
 import { DisclosureMenu } from "../../../index";

--- a/tests/menus/DisclosureMenu/internal.test.js
+++ b/tests/menus/DisclosureMenu/internal.test.js
@@ -1,7 +1,5 @@
 /**
  * Test the DisclosureMenu class's internal methods.
- *
- * @jest-environment jsdom
  */
 
 import { DisclosureMenu } from "../../../index";

--- a/tests/menus/DisclosureMenu/sanity.test.js
+++ b/tests/menus/DisclosureMenu/sanity.test.js
@@ -1,7 +1,5 @@
 /**
  * Test the DisclosureMenu class to make sure it "just works".
- *
- * @jest-environment jsdom
  */
 
 import { DisclosureMenu } from "../../../index";

--- a/tests/menus/Menubar/aria.test.js
+++ b/tests/menus/Menubar/aria.test.js
@@ -1,7 +1,5 @@
 /**
  * Test the Menubar class for proper ARIA attributes.
- *
- * @jest-environment jsdom
  */
 
 import { Menubar } from "../../../index";

--- a/tests/menus/Menubar/functional.test.js
+++ b/tests/menus/Menubar/functional.test.js
@@ -1,7 +1,5 @@
 /**
  * Test the Menubar class to make sure it functions correctly.
- *
- * @jest-environment jsdom
  */
 
 import { Menubar } from "../../../index";

--- a/tests/menus/Menubar/initialization.test.js
+++ b/tests/menus/Menubar/initialization.test.js
@@ -1,7 +1,5 @@
 /**
  * Test the Menubar class to make sure it can initialize under various scenarios.
- *
- * @jest-environment jsdom
  */
 
 import { Menubar } from "../../../index";

--- a/tests/menus/Menubar/internal.test.js
+++ b/tests/menus/Menubar/internal.test.js
@@ -1,7 +1,5 @@
 /**
  * Test the Menubar class's internal methods.
- *
- * @jest-environment jsdom
  */
 
 import { Menubar } from "../../../index";

--- a/tests/menus/Menubar/sanity.test.js
+++ b/tests/menus/Menubar/sanity.test.js
@@ -1,7 +1,5 @@
 /**
  * Test the Menubar class to make sure it "just works".
- *
- * @jest-environment jsdom
  */
 
 import { Menubar } from "../../../index";

--- a/tests/menus/Treeview/aria.test.js
+++ b/tests/menus/Treeview/aria.test.js
@@ -1,7 +1,5 @@
 /**
  * Test the Treeview class for proper ARIA attributes.
- *
- * @jest-environment jsdom
  */
 
 import { Treeview } from "../../../index";

--- a/tests/menus/Treeview/functional.test.js
+++ b/tests/menus/Treeview/functional.test.js
@@ -1,7 +1,5 @@
 /**
  * Test the Treeview class to make sure it functions correctly.
- *
- * @jest-environment jsdom
  */
 
 import { Treeview } from "../../../index";

--- a/tests/menus/Treeview/initialization.test.js
+++ b/tests/menus/Treeview/initialization.test.js
@@ -1,7 +1,5 @@
 /**
  * Test the Treeview class to make sure it can initialize under various scenarios.
- *
- * @jest-environment jsdom
  */
 
 import { Treeview } from "../../../index";

--- a/tests/menus/Treeview/internal.test.js
+++ b/tests/menus/Treeview/internal.test.js
@@ -1,7 +1,5 @@
 /**
  * Test the Treeview class's internal methods.
- *
- * @jest-environment jsdom
  */
 
 import { Treeview } from "../../../index";

--- a/tests/menus/Treeview/sanity.test.js
+++ b/tests/menus/Treeview/sanity.test.js
@@ -1,7 +1,5 @@
 /**
  * Test the Treeview class to make sure it "just works".
- *
- * @jest-environment jsdom
  */
 
 import { Treeview } from "../../../index";

--- a/tests/menus/_common/aria.js
+++ b/tests/menus/_common/aria.js
@@ -1,7 +1,5 @@
 /**
  * Reusable ARIA tests.
- *
- * @jest-environment jsdom
  */
 /* eslint-disable no-new */
 

--- a/tests/menus/_common/functional.js
+++ b/tests/menus/_common/functional.js
@@ -1,7 +1,5 @@
 /**
  * Reusable functional tests.
- *
- * @jest-environment jsdom
  */
 /* eslint-disable no-new */
 

--- a/tests/menus/_common/helpers.js
+++ b/tests/menus/_common/helpers.js
@@ -4,7 +4,8 @@
 
 /**
  * Extends jsdom MouseEvent class as PointerEvent class
- * NOTE: It should be deprecated if JSDOM fully supports PointEvent in the future
+ *
+ * @todo: deprecate if/when JSDOM fully supports PointerEvents.
  */
 class PointerEvent extends window.MouseEvent {
   constructor(type, props) {

--- a/tests/menus/_common/initialize.js
+++ b/tests/menus/_common/initialize.js
@@ -1,7 +1,5 @@
 /**
  * Reusable initialization tests.
- *
- * @jest-environment jsdom
  */
 /* eslint-disable no-new */
 

--- a/tests/menus/_common/internal.js
+++ b/tests/menus/_common/internal.js
@@ -1,7 +1,5 @@
 /**
  * Reusable internal menu function tests.
- *
- * @jest-environment jsdom
  */
 
 import { twoLevelMenu } from "./test-menus";

--- a/tests/menus/_common/sanity.js
+++ b/tests/menus/_common/sanity.js
@@ -1,7 +1,5 @@
 /**
  * Reusable tests to make sure menus "just work".
- *
- * @jest-environment jsdom
  */
 
 import { oneLevelMenu, twoLevelMenu } from "./test-menus";

--- a/tests/validate/isCSSSelector.test.js
+++ b/tests/validate/isCSSSelector.test.js
@@ -1,7 +1,5 @@
 /**
  * Test the isCSSSelector() function in validate.js to make sure the expected values are returned.
- *
- * @jest-environment jsdom
  */
 
 import { isCSSSelector } from "../../src/validate";

--- a/tests/validate/isEventSupported.test.js
+++ b/tests/validate/isEventSupported.test.js
@@ -2,8 +2,6 @@
  * Test the isEventSupported() function in validate.js to make sure the expected values are returned.
  *
  * @deprecated Will be removed in v4.
- *
- * @jest-environment jsdom
  */
 
 import { isEventSupported } from "../../src/validate";

--- a/tests/validate/isTag.test.js
+++ b/tests/validate/isTag.test.js
@@ -1,7 +1,5 @@
 /**
  * Test the isTag() function in validate.js to make sure the expected values are returned.
- *
- * @jest-environment jsdom
  */
 
 import { isTag } from "../../src/validate";

--- a/tests/validate/isValidClassList.test.js
+++ b/tests/validate/isValidClassList.test.js
@@ -1,7 +1,5 @@
 /**
  * Test the isValidClassList() function in validate.js to make sure the expected values are returned.
- *
- * @jest-environment jsdom
  */
 
 import { isValidClassList } from "../../src/validate";

--- a/tests/validate/isValidInstance.test.js
+++ b/tests/validate/isValidInstance.test.js
@@ -1,7 +1,5 @@
 /**
  * Test the isValidInstance() function in validate.js to make sure the expected values are returned.
- *
- * @jest-environment jsdom
  */
 
 import { isValidInstance } from "../../src/validate";


### PR DESCRIPTION
## Description
<!-- Why are you making this pull request? -->
Some tests are failing because of jsdom latest making some seemingly breaking changes. Using standard jsdom appears to work for all tests now, so removing a dev dependency isn't bad.
