### PR TITLE
build: use test run script for prerelease

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "npm run eslint -- --fix && npm run prettier -- --write",
     "eslint": "eslint --ext .js .",
     "prettier": "prettier '**/*.js' --ignore-path .eslintignore",
-    "prerelease": "npm run lint && npm run build && npm test",
+    "prerelease": "npm run lint && npm run build && npm test:run",
     "release": "git add dist/. && standard-version -a",
     "prebuild": "npm run build:docs",
     "build": "npm run build:default; npm run build:disclosure-menu; npm run build:menubar; npm run build:top-link-disclosure-menu; npm run build:treeview",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "npm run eslint -- --fix && npm run prettier -- --write",
     "eslint": "eslint --ext .js .",
     "prettier": "prettier '**/*.js' --ignore-path .eslintignore",
-    "prerelease": "npm run lint && npm run build && npm test:run",
+    "prerelease": "npm run lint && npm run build && npm run test:run",
     "release": "git add dist/. && standard-version -a",
     "prebuild": "npm run build:docs",
     "build": "npm run build:default; npm run build:disclosure-menu; npm run build:menubar; npm run build:top-link-disclosure-menu; npm run build:treeview",


### PR DESCRIPTION
## Description
The test script is now watching for changes, not to be used for commands that need to only run the tests once.

Swapping to the new "test:run" fixes this (just like in the workflow).
