### PR TITLE
fix(menubar): properly focus parent menu current child when closing

### DIFF
--- a/src/menubarToggle.js
+++ b/src/menubarToggle.js
@@ -73,7 +73,10 @@ class MenubarToggle extends BaseMenuToggle {
     if (this.isOpen) {
       // Close all children.
       this.closeChildren();
-      this.elements.parentMenu.focusCurrentChild();
+
+      if (this.elements.parentMenu) {
+        this.elements.parentMenu.focusCurrentChild();
+      }
     }
 
     super.close();

--- a/src/menubarToggle.js
+++ b/src/menubarToggle.js
@@ -73,6 +73,7 @@ class MenubarToggle extends BaseMenuToggle {
     if (this.isOpen) {
       // Close all children.
       this.closeChildren();
+      this.elements.parentMenu.focusCurrentChild();
     }
 
     super.close();

--- a/tests/menus/MenubarToggle/public.test.js
+++ b/tests/menus/MenubarToggle/public.test.js
@@ -310,6 +310,49 @@ describe("MenubarToggle public methods", () => {
 
       expect(spy).toHaveBeenCalled();
     });
+
+    // Test that close calls the parent menu's focusCurrentChild method.
+    it("should call the parent menu's focusCurrentChild method", () => {
+      // Create a new Menubar instance for testing.
+      const menu = new Menubar({
+        menuElement: document.querySelector("ul"),
+        submenuItemSelector: "li.dropdown",
+        containerElement: document.querySelector("nav"),
+        controllerElement: document.querySelector("button"),
+      });
+
+      const menuToggle = menu.elements.submenuToggles[0];
+
+      // Set up to check for closeChildren() call.
+      const spy = vi.spyOn(menu, "focusCurrentChild");
+
+      // Set up the menu.
+      menuToggle.isOpen = true;
+
+      menuToggle.close();
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    // Test that close does not call the parent menu's focusCurrentChild method is the parent menu does not exist.
+    it("should not call the parent menu's focusCurrentChild method is the parent menu does not exist", () => {
+      // Create a new Menubar instance for testing.
+      const menu = new Menubar({
+        menuElement: document.querySelector("ul"),
+        submenuItemSelector: "li.dropdown",
+        containerElement: document.querySelector("nav"),
+        controllerElement: document.querySelector("button"),
+      });
+
+      const menuToggle = menu.elements.controller;
+
+      // Set up the menu.
+      menuToggle.isOpen = true;
+
+      expect(() => {
+        menuToggle.close();
+      }).not.toThrow();
+    });
   });
 
   // Test MenubarToggle toggle().


### PR DESCRIPTION
## Description
This resolves an issue where you can lose the ability to tab into menubars
