### PR TITLE
build(npm): remove @babel/eslint-parser from dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,6 @@
   "homepage": "https://github.com/NickDJM/accessible-menu#readme",
   "devDependencies": {
     "@babel/core": "^7.22.5",
-    "@babel/eslint-parser": "^7.22.5",
     "@babel/preset-env": "^7.22.5",
     "@commitlint/cli": "^19.0.3",
     "@commitlint/config-conventional": "^19.0.3",


### PR DESCRIPTION
## Description

I think this was needed for jest tests, but vitest works just fine without it
