### PR TITLE
fix(treeview): only close submenus when menu recieves pointerleave event

### DIFF
--- a/docs/api/treeview.md
+++ b/docs/api/treeview.md
@@ -127,6 +127,37 @@ Getters and setters are inherited from the [BaseMenu](./base-menu#getters-and-se
 
 Methods are inherited from the [BaseMenu](./base-menu#methods) class. The following methods are unique to or overwritten in the Treeview class.
 
+### _handleHover <badge type="warning" text="protected" /> {#method--handlehover}
+
+Handles hover events throughout the menu for proper use.
+
+```js
+BaseMenu._handleHover();
+```
+
+Adds `pointerenter` listeners to all menu items and `pointerleave` listeners to all submenu items which function differently depending on the menu's [hover type](#property--hovertype).
+
+Before executing anything, the event is checked to make sure the event wasn't triggered by a pen or touch.
+
+This method will add the following behaviour:
+
+#### Hover Type "on" {#method--handlefover--hovertype-on}
+
+- When a `pointerenter` event triggers on any menu item the menu's [current child](#property--currentchild) value will change to that menu item.
+- When a `pointerenter` event triggers on a submenu item the [preview method](./base-menu-toggle#method--preview) for the submenu item's toggle will be called.
+- When a `pointerleave` event triggers on the menu itself the [closeChildren method](./base-menu#method--closechildren) will be called after a delay set by the menu's hover delay.
+
+#### Hover Type "dynamic" {#method--handlefover--hovertype-dynamic}
+
+- When a `pointerenter` event triggers on any menu item the menu's current child value will change to that menu item.
+- When a `pointerenter` event triggers on any menu item, and the menu's [focus state](#property--focusstate) is not "none", the menu item will be focused.
+- When a `pointerenter` event triggers on a submenu item, and a submenu is already open, the preview method for the submenu item's toggle will be called.
+- When a `pointerenter` event triggers on a submenu item, and no submenu is open, no submenu-specific methods will be called.
+
+#### Hover Type "off" {#method--handlefover--hovertype-off}
+
+All `pointerenter` and `pointerleave` events are ignored.
+
 ### _handleKeydown <badge type="warning" text="protected" /> {#method--handlekeydown}
 
 Handles keydown events throughout the menu for proper menu use.

--- a/docs/hover-types.md
+++ b/docs/hover-types.md
@@ -26,6 +26,10 @@ new DisclosureMenu({
 });
 ```
 
+### Treeviews and Hover On
+
+When using a treeview menu with hover **on**, `pointerenter` events are triggered as expected, however `pointerleave` events are handled differently. Leaving a menu item that is open will _not_ close that menu in a treeview. The only way a `pointerleave` event will close a menu item is if the root menu itself is left. This is to prevent a lot of visual confusion when hovering/unhover menu items in a treeview.
+
 ## Hover Dynamic
 
 Hover **dynamic** is a hybrid of hover **off** and hover **on**. The menu will function as if it is in hover **off** mode until the user clicks a menu toggle to open a submenu. Once a submenu is open, the menu will function as if it is in hover **on** mode until the user clicks outside of the menu to close all submenus.
@@ -37,3 +41,7 @@ new DisclosureMenu({
   hoverType: "dynamic", // Default: "off".
 });
 ```
+
+### Treeviews and Hover Dynamic
+
+When using a treeview menu with hover **dynamic**, `pointerenter` events are triggered as expected, however `pointerleave` events are handled differently. Leaving a menu item that is open will _not_ close that menu in a treeview. A menu must be manually closed through clicking it's toggle to close it.

--- a/src/treeview.js
+++ b/src/treeview.js
@@ -300,12 +300,10 @@ class Treeview extends BaseMenu {
               if (this.leaveDelay > 0) {
                 this._clearTimeout();
                 this._setTimeout(() => {
-                  this.currentEvent = "mouse";
                   this.closeChildren();
                   this.blur();
                 }, this.leaveDelay);
               } else {
-                this.currentEvent = "mouse";
                 this.closeChildren();
                 this.blur();
               }

--- a/src/treeview.js
+++ b/src/treeview.js
@@ -158,6 +158,165 @@ class Treeview extends BaseMenu {
   }
 
   /**
+   * Handles hover events throughout the menu for proper use.
+   *
+   * Adds `pointerenter` listeners to all menu items and `pointerleave` listeners
+   * to all submenu items which function differently depending on
+   * the menu's hover type.
+   *
+   * Before executing anything, the event is checked to make sure the event wasn't
+   * triggered by a pen or touch.
+   *
+   * <strong>Hover Type "on"</strong>
+   * - When a `pointerenter` event triggers on any menu item the menu's
+   *    current child value will change to that
+   *   menu item.
+   * - When a `pointerenter` event triggers on a submenu item the
+   *   preview method for the submenu item's
+   *   toggle will be called.
+   * - When a `pointerleave` event triggers on the menu itself the
+   *   closeChildren method will be called after a delay
+   *   set by the menu's hover delay.
+   *
+   * <strong>Hover Type "dynamic"</strong>
+   * - When a `pointerenter` event triggers on any menu item the menu's
+   *   current child value will change to that menu item.
+   * - When a `pointerenter` event triggers on any menu item, and the menu's
+   *   focus state is not "none", the menu item
+   *   will be focused.
+   * - When a `pointerenter` event triggers on a submenu item, and a submenu is
+   *   already open, the preview method for the submenu item's toggle will be called.
+   * - When a `pointerenter` event triggers on a submenu item, and no submenu is
+   *   open, no submenu-specific methods will be called.
+   * - When a `pointerleave` event triggers on an open submenu item that is not a
+   *   root-level submenu item the close method for the submenu item's toggle
+   *   will be called and the submenu item will be focused after a delay set by
+   *   the menu's hover delay.
+   * - When a `pointerleave` event triggers on an open submenu item that is a
+   *   root-level submenu item no submenu-specific methods will be called.
+   *
+   * <strong>Hover Type "off"</strong>
+   * All `pointerenter` and `pointerleave` events are ignored.
+   *
+   * @protected
+   */
+  _handleHover() {
+    this.elements.menuItems.forEach((menuItem, index) => {
+      menuItem.dom.link.addEventListener("pointerenter", (event) => {
+        // Exit out of the event if it was not made by a mouse.
+        if (event.pointerType === "pen" || event.pointerType === "touch") {
+          return;
+        }
+
+        if (this.hoverType === "on") {
+          this.currentEvent = "mouse";
+          this.elements.rootMenu.blurChildren();
+          this.focusChild(index);
+
+          if (menuItem.isSubmenuItem) {
+            if (this.enterDelay > 0) {
+              this._clearTimeout();
+              this._setTimeout(() => {
+                menuItem.elements.toggle.preview();
+              }, this.enterDelay);
+            } else {
+              menuItem.elements.toggle.preview();
+            }
+          }
+        } else if (this.hoverType === "dynamic") {
+          const isOpen = this.elements.submenuToggles.some(
+            (toggle) => toggle.isOpen
+          );
+
+          this.currentChild = index;
+
+          if (!this.isTopLevel || this.focusState !== "none") {
+            this.currentEvent = "mouse";
+            this.elements.rootMenu.blurChildren();
+            this.focusCurrentChild();
+          }
+
+          if (menuItem.isSubmenuItem && (!this.isTopLevel || isOpen)) {
+            this.currentEvent = "mouse";
+            this.elements.rootMenu.blurChildren();
+            this.focusCurrentChild();
+
+            if (this.enterDelay > 0) {
+              this._clearTimeout();
+              this._setTimeout(() => {
+                menuItem.elements.toggle.preview();
+              }, this.enterDelay);
+            } else {
+              menuItem.elements.toggle.preview();
+            }
+          }
+        }
+      });
+
+      if (menuItem.isSubmenuItem) {
+        menuItem.dom.item.addEventListener("pointerleave", (event) => {
+          // Exit out of the event if it was not made by a mouse.
+          if (event.pointerType === "pen" || event.pointerType === "touch") {
+            return;
+          }
+
+          if (this.hoverType === "on") {
+            if (this.leaveDelay > 0) {
+              this._clearTimeout();
+            }
+          } else if (this.hoverType === "dynamic") {
+            if (!this.isTopLevel) {
+              if (this.leaveDelay > 0) {
+                this._clearTimeout();
+              }
+            }
+          }
+        });
+
+        // Clear hover timeouts any time the mouse enters an item with a submenu. This prevents the
+        // menu from closing if the mouse leaves but then re-enters before leaveDelay has elapsed.
+        menuItem.dom.item.addEventListener("pointerenter", (event) => {
+          // Exit out of the event if it was not made by a mouse.
+          if (event.pointerType === "pen" || event.pointerType === "touch") {
+            return;
+          }
+          if (
+            menuItem.isSubmenuItem &&
+            (this.hoverType === "on" || this.hoverType === "dynamic") &&
+            this.leaveDelay > 0
+          ) {
+            this._clearTimeout();
+          }
+        });
+
+        if (this.isTopLevel) {
+          this.dom.menu.addEventListener("pointerleave", (event) => {
+            // Exit out of the event if it was not made by a mouse.
+            if (event.pointerType === "pen" || event.pointerType === "touch") {
+              return;
+            }
+
+            if (this.hoverType === "on") {
+              if (this.leaveDelay > 0) {
+                this._clearTimeout();
+                this._setTimeout(() => {
+                  this.currentEvent = "mouse";
+                  this.closeChildren();
+                  this.blur();
+                }, this.leaveDelay);
+              } else {
+                this.currentEvent = "mouse";
+                this.closeChildren();
+                this.blur();
+              }
+            }
+          });
+        }
+      }
+    });
+  }
+
+  /**
    * Handles keydown events throughout the menu for proper menu use.
    *
    * This method exists to assist the _handleKeyup method.

--- a/src/treeview.js
+++ b/src/treeview.js
@@ -188,12 +188,6 @@ class Treeview extends BaseMenu {
    *   already open, the preview method for the submenu item's toggle will be called.
    * - When a `pointerenter` event triggers on a submenu item, and no submenu is
    *   open, no submenu-specific methods will be called.
-   * - When a `pointerleave` event triggers on an open submenu item that is not a
-   *   root-level submenu item the close method for the submenu item's toggle
-   *   will be called and the submenu item will be focused after a delay set by
-   *   the menu's hover delay.
-   * - When a `pointerleave` event triggers on an open submenu item that is a
-   *   root-level submenu item no submenu-specific methods will be called.
    *
    * <strong>Hover Type "off"</strong>
    * All `pointerenter` and `pointerleave` events are ignored.

--- a/tests/menus/Treeview/hover.test.js
+++ b/tests/menus/Treeview/hover.test.js
@@ -1,0 +1,1093 @@
+/**
+ * Hover tests for the Treeview class.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  vi,
+} from "vitest";
+import { threeLevel } from "../../../demo/menus.js";
+import Treeview from "../../../src/treeview.js";
+import { simulatePointerEvent, PointerEvent } from "../helpers.js";
+
+beforeAll(() => {
+  // Extend jsdom MouseEvent class as PointerEvent class.
+  window.PointerEvent = PointerEvent;
+});
+
+beforeEach(() => {
+  // Create the test menu.
+  document.body.innerHTML = threeLevel;
+
+  // Make sure to use fake timers.
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  // Remove the test menu.
+  document.body.innerHTML = "";
+
+  // Restore the timers.
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+});
+
+// Test hover events on the Treeview.
+describe("Treeview", () => {
+  // Test hover type on.
+  describe("with hover type on", () => {
+    // Test pointerenter.
+    describe("pointerenter", () => {
+      // Test that the menu's current event is set to mouse when a menu item is hovered.
+      it("should set the menu's current event to mouse when a menu item is hovered", () => {
+        // Create a new Treeview instance for testing.
+        const menu = new Treeview({
+          menuElement: document.querySelector("ul"),
+          submenuItemSelector: "li.dropdown",
+          containerElement: document.querySelector("nav"),
+          controllerElement: document.querySelector("button"),
+          hoverType: "on",
+        });
+
+        // Simulate the pointerenter event.
+        simulatePointerEvent(
+          "pointerenter",
+          menu.elements.menuItems[0].dom.link
+        );
+
+        expect(menu.currentEvent).toBe("mouse");
+      });
+      // Test that the room menu's blurChildren method is called when a menu item is hovered.
+      it("should call the root menu's blurChildren method when a menu item is hovered", () => {
+        // Create a new Treeview instance for testing.
+        const menu = new Treeview({
+          menuElement: document.querySelector("ul"),
+          submenuItemSelector: "li.dropdown",
+          containerElement: document.querySelector("nav"),
+          controllerElement: document.querySelector("button"),
+          hoverType: "on",
+        });
+
+        // Spy on the root menu's blurChildren method.
+        const spy = vi.spyOn(menu.elements.rootMenu, "blurChildren");
+
+        // Simulate the pointerenter event.
+        simulatePointerEvent(
+          "pointerenter",
+          menu.elements.menuItems[0].dom.link
+        );
+
+        expect(spy).toHaveBeenCalled();
+      });
+      // Test that the menu's focusChild method is called with the hovered menu item's index.
+      it.each([1, 2, 3, 4, 5, 6, 7])(
+        "should call the menu's focusChild method with menu item %s's index",
+        (i) => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "on",
+          });
+
+          // Spy on the menu's focusChild method.
+          const spy = vi.spyOn(menu, "focusChild");
+
+          // Simulate the pointerenter event.
+          simulatePointerEvent(
+            "pointerenter",
+            menu.elements.menuItems[i].dom.link
+          );
+
+          expect(spy).toHaveBeenCalledWith(i);
+        }
+      );
+      // Test that clearTimeout is called when a submenu item is hovered.
+      it("should call clearTimeout when a submenu item is hovered", () => {
+        // Create a new Treeview instance for testing.
+        const menu = new Treeview({
+          menuElement: document.querySelector("ul"),
+          submenuItemSelector: "li.dropdown",
+          containerElement: document.querySelector("nav"),
+          controllerElement: document.querySelector("button"),
+          hoverType: "on",
+        });
+
+        // Spy on the menu's clearTimeout method.
+        const spy = vi.spyOn(menu, "_clearTimeout");
+
+        // Simulate the pointerenter event.
+        simulatePointerEvent(
+          "pointerenter",
+          menu.elements.menuItems[1].dom.link
+        );
+
+        expect(spy).toHaveBeenCalled();
+      });
+      // Test that preview is called after a delay when a submenu item is hovered.
+      it("should call preview after a delay when a submenu item is hovered", () => {
+        // Create a new Treeview instance for testing.
+        const menu = new Treeview({
+          menuElement: document.querySelector("ul"),
+          submenuItemSelector: "li.dropdown",
+          containerElement: document.querySelector("nav"),
+          controllerElement: document.querySelector("button"),
+          hoverType: "on",
+        });
+
+        // Spy on the menu's preview method.
+        const spy = vi.spyOn(menu.elements.submenuToggles[0], "preview");
+
+        // Simulate the pointerenter event.
+        simulatePointerEvent(
+          "pointerenter",
+          menu.elements.menuItems[1].dom.link
+        );
+
+        // Advance the timers by the menu's enter delay.
+        vi.advanceTimersByTime(menu.enterDelay);
+
+        vi.waitFor(() => expect(spy).toHaveBeenCalled(), {
+          timeout: 10000,
+          interval: 10,
+        });
+      });
+      // Test that preview is called immediately when a submenu item is hovered and enterDelay is set to 0.
+      it("should call preview immediately when a submenu item is hovered and enterDelay is set to 0", () => {
+        // Create a new Treeview instance for testing.
+        const menu = new Treeview({
+          menuElement: document.querySelector("ul"),
+          submenuItemSelector: "li.dropdown",
+          containerElement: document.querySelector("nav"),
+          controllerElement: document.querySelector("button"),
+          hoverType: "on",
+          enterDelay: 0,
+        });
+
+        // Spy on the menu's preview method.
+        const spy = vi.spyOn(menu.elements.submenuToggles[0], "preview");
+
+        // Simulate the pointerenter event.
+        simulatePointerEvent(
+          "pointerenter",
+          menu.elements.menuItems[1].dom.link
+        );
+
+        expect(spy).toHaveBeenCalled();
+      });
+    });
+    // Test pointerleave.
+    describe("pointerleave", () => {
+      describe("when a menu item is a submenu item", () => {
+        // Test that clearTimeout is called when a menu item is unhovered.
+        it("should call clearTimeout when a menu item is unhovered", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "on",
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Spy on clearTimeout.
+          const spy = vi.spyOn(menu, "_clearTimeout");
+
+          // Simulate the pointerleave event.
+          simulatePointerEvent(
+            "pointerleave",
+            menu.elements.menuItems[1].dom.link
+          );
+
+          expect(spy).toHaveBeenCalled();
+        });
+        // Test that clearTimeout is not called when a menu item is unhovered and leaveDelay is set to 0.
+        it("should not call clearTimeout when a menu item is unhovered and leaveDelay is set to 0", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "on",
+            leaveDelay: 0,
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Spy on clearTimeout.
+          const spy = vi.spyOn(menu, "_clearTimeout");
+
+          // Simulate the pointerleave event.
+          simulatePointerEvent(
+            "pointerleave",
+            menu.elements.menuItems[1].dom.link
+          );
+
+          expect(spy).not.toHaveBeenCalled();
+        });
+      });
+      describe("when a menu is the root menu", () => {
+        // Test that clearTimeout is called when a menu is unhovered.
+        it("should call clearTimeout when a menu is unhovered", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "on",
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Spy on clearTimeout.
+          const spy = vi.spyOn(menu, "_clearTimeout");
+
+          // Simulate the pointerleave event.
+          simulatePointerEvent("pointerleave", menu.dom.menu);
+
+          expect(spy).toHaveBeenCalled();
+        });
+        // Test that clearTimeout is not called when a menu is unhovered and leaveDelay is set to 0.
+        it("should not call clearTimeout when a menu is unhovered and leaveDelay is set to 0", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "on",
+            leaveDelay: 0,
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Spy on clearTimeout.
+          const spy = vi.spyOn(menu, "_clearTimeout");
+
+          // Simulate the pointerleave event.
+          simulatePointerEvent("pointerleave", menu.dom.menu);
+
+          expect(spy).not.toHaveBeenCalled();
+        });
+        // Test that closeChildren is called after a delay when a menu is unhovered.
+        it("should call closeChildren after a delay when a menu is unhovered", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "on",
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Spy on closeChildren.
+          const spy = vi.spyOn(menu, "closeChildren");
+
+          // Simulate the pointerleave event.
+          simulatePointerEvent("pointerleave", menu.dom.menu);
+
+          // Advance the timers by the menu's leave delay.
+          vi.advanceTimersByTime(menu.leaveDelay);
+
+          vi.waitFor(() => expect(spy).toHaveBeenCalled(), {
+            timeout: 10000,
+            interval: 10,
+          });
+        });
+        // Test that closeChildren is called immediately when a menu is unhovered and leaveDelay is set to 0.
+        it("should call closeChildren immediately when a menu is unhovered and leaveDelay is set to 0", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "on",
+            leaveDelay: 0,
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Spy on closeChildren.
+          const spy = vi.spyOn(menu, "closeChildren");
+
+          // Simulate the pointerleave event.
+          simulatePointerEvent("pointerleave", menu.dom.menu);
+
+          expect(spy).toHaveBeenCalled();
+        });
+        // Test that blur is called after a delay when a menu is unhovered.
+        it("should call blur after a delay when a menu is unhovered", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "on",
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Spy on blur.
+          const spy = vi.spyOn(menu, "blur");
+
+          // Simulate the pointerleave event.
+          simulatePointerEvent("pointerleave", menu.dom.menu);
+
+          // Advance the timers by the menu's leave delay.
+          vi.advanceTimersByTime(menu.leaveDelay);
+
+          vi.waitFor(() => expect(spy).toHaveBeenCalled(), {
+            timeout: 10000,
+            interval: 10,
+          });
+        });
+        // Test that blur is called immediately when a menu is unhovered and leaveDelay is set to 0.
+        it("should call blur immediately when a menu is unhovered and leaveDelay is set to 0", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "on",
+            leaveDelay: 0,
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Spy on blur.
+          const spy = vi.spyOn(menu, "blur");
+
+          // Simulate the pointerleave event.
+          simulatePointerEvent("pointerleave", menu.dom.menu);
+
+          expect(spy).toHaveBeenCalled();
+        });
+      });
+      describe("when a menu is not the root menu", () => {
+        // Test that closeChildren is not called when a menu is unhovered.
+        it("should not call closeChildren when a menu is unhovered", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "on",
+            leaveDelay: 0,
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+          menu.elements.submenuToggles[0].elements.controlledMenu.currentChild = 1;
+
+          // Spy on closeChildren.
+          const spy = vi.spyOn(menu, "closeChildren");
+
+          // Simulate the pointerleave event.
+          simulatePointerEvent(
+            "pointerleave",
+            menu.elements.submenuToggles[0].elements.controlledMenu
+          );
+
+          expect(spy).not.toHaveBeenCalled();
+        });
+        // Test that blur is not called when a menu is unhovered.
+        it("should not call blur when a menu is unhovered", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "on",
+            leaveDelay: 0,
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+          menu.elements.submenuToggles[0].elements.controlledMenu.currentChild = 1;
+
+          // Spy on blur.
+          const spy = vi.spyOn(menu, "blur");
+
+          // Simulate the pointerleave event.
+          simulatePointerEvent(
+            "pointerleave",
+            menu.elements.submenuToggles[0].elements.controlledMenu
+          );
+
+          expect(spy).not.toHaveBeenCalled();
+        });
+      });
+    });
+  });
+  // Test hover type dynamic.
+  describe("with hover type dynamic", () => {
+    // Test pointerenter.
+    describe("pointerenter", () => {
+      // Test that the menu's current child is set to the hovered menu item's index.
+      describe("if the menu is not the root menu", () => {
+        // Test that the menu's current event is set to mouse when a menu item is hovered.
+        it("should set the menu's current event to mouse when a menu item is hovered", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "dynamic",
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Simulate the pointerenter event.
+          simulatePointerEvent(
+            "pointerenter",
+            menu.elements.submenuToggles[0].elements.controlledMenu.elements
+              .menuItems[1].dom.link
+          );
+
+          expect(
+            menu.elements.submenuToggles[0].elements.controlledMenu.currentEvent
+          ).toBe("mouse");
+        });
+        // Test that the root menu's blurChildren method is called when a menu item is hovered.
+        it("should call the root menu's blurChildren method when a menu item is hovered", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "dynamic",
+          });
+
+          // Spy on the root menu's blurChildren method.
+          const spy = vi.spyOn(
+            menu.elements.submenuToggles[0].elements.controlledMenu.elements
+              .rootMenu,
+            "blurChildren"
+          );
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Simulate the pointerenter event.
+          simulatePointerEvent(
+            "pointerenter",
+            menu.elements.submenuToggles[0].elements.controlledMenu.elements
+              .menuItems[1].dom.link
+          );
+
+          expect(spy).toHaveBeenCalled();
+        });
+        // Test that the menu's focusCurrentChild method is called when a menu item is hovered.
+        it("should call the menu's focusCurrentChild method when a menu item is hovered", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "dynamic",
+          });
+
+          // Spy on the menu's focusCurrentChild method.
+          const spy = vi.spyOn(
+            menu.elements.submenuToggles[0].elements.controlledMenu,
+            "focusCurrentChild"
+          );
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Simulate the pointerenter event.
+          simulatePointerEvent(
+            "pointerenter",
+            menu.elements.submenuToggles[0].elements.controlledMenu.elements
+              .menuItems[1].dom.link
+          );
+
+          expect(spy).toHaveBeenCalled();
+        });
+      });
+      describe("if the menu is the root menu and the focus state is not none", () => {
+        // Test that the menu's current event is set to mouse when a menu item is hovered.
+        it("should set the menu's current event to mouse when a menu item is hovered", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "dynamic",
+          });
+
+          // Set up the menu.
+          menu.focusState = "self";
+
+          // Simulate the pointerenter event.
+          simulatePointerEvent(
+            "pointerenter",
+            menu.elements.menuItems[0].dom.link
+          );
+
+          expect(menu.currentEvent).toBe("mouse");
+        });
+        // Test that the root menu's blurChildren method is called when a menu item is hovered.
+        it("should call the root menu's blurChildren method when a menu item is hovered", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "dynamic",
+          });
+
+          // Set up the menu.
+          menu.focusState = "self";
+
+          // Spy on the root menu's blurChildren method.
+          const spy = vi.spyOn(menu.elements.rootMenu, "blurChildren");
+
+          // Simulate the pointerenter event.
+          simulatePointerEvent(
+            "pointerenter",
+            menu.elements.menuItems[0].dom.link
+          );
+
+          expect(spy).toHaveBeenCalled();
+        });
+        // Test that the menu's focusCurrentChild method is called when a menu item is hovered.
+        it("should call the menu's focusCurrentChild method when a menu item is hovered", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "dynamic",
+          });
+
+          // Set up the menu.
+          menu.focusState = "self";
+
+          // Spy on the menu's focusCurrentChild method.
+          const spy = vi.spyOn(menu, "focusCurrentChild");
+
+          // Simulate the pointerenter event.
+          simulatePointerEvent(
+            "pointerenter",
+            menu.elements.menuItems[0].dom.link
+          );
+
+          expect(spy).toHaveBeenCalled();
+        });
+      });
+      describe("if the menu is the root menu and the focus state is none", () => {
+        // Test that the menu's current event is not set to mouse when a menu item is hovered.
+        it("should not set the menu's current event to mouse when a menu item is hovered", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "dynamic",
+          });
+
+          // Simulate the pointerenter event.
+          simulatePointerEvent(
+            "pointerenter",
+            menu.elements.menuItems[0].dom.link
+          );
+
+          expect(menu.currentEvent).toBe("none");
+        });
+        // Test that the root menu's blurChildren method not is called when a menu item is hovered.
+        it("should not call the root menu's blurChildren method when a menu item is hovered", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "dynamic",
+          });
+
+          // Spy on the root menu's blurChildren method.
+          const spy = vi.spyOn(menu.elements.rootMenu, "blurChildren");
+
+          // Simulate the pointerenter event.
+          simulatePointerEvent(
+            "pointerenter",
+            menu.elements.menuItems[0].dom.link
+          );
+
+          expect(spy).not.toHaveBeenCalled();
+        });
+        // Test that the menu's focusCurrentChild method is not called when a menu item is hovered.
+        it("should not call the menu's focusCurrentChild method when a menu item is hovered", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "dynamic",
+          });
+
+          // Spy on the menu's focusCurrentChild method.
+          const spy = vi.spyOn(menu, "focusCurrentChild");
+
+          // Simulate the pointerenter event.
+          simulatePointerEvent(
+            "pointerenter",
+            menu.elements.menuItems[0].dom.link
+          );
+
+          expect(spy).not.toHaveBeenCalled();
+        });
+      });
+      describe("if the menu item is a submenu item and the menu is not the root menu", () => {
+        // Test that the menu's current event is set to mouse.
+        it("should set the menu's current event to mouse", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "dynamic",
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Simulate the pointerenter event.
+          simulatePointerEvent(
+            "pointerenter",
+            menu.elements.submenuToggles[0].elements.controlledMenu.elements
+              .menuItems[1].dom.link
+          );
+
+          expect(
+            menu.elements.submenuToggles[0].elements.controlledMenu.currentEvent
+          ).toBe("mouse");
+        });
+        // Test that the root menu's blurChildren method is called.
+        it("should call the root menu's blurChildren method", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "dynamic",
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Spy on the root menu's blurChildren method.
+          const spy = vi.spyOn(
+            menu.elements.submenuToggles[0].elements.controlledMenu.elements
+              .rootMenu,
+            "blurChildren"
+          );
+
+          // Simulate the pointerenter event.
+          simulatePointerEvent(
+            "pointerenter",
+            menu.elements.submenuToggles[0].elements.controlledMenu.elements
+              .menuItems[1].dom.link
+          );
+
+          expect(spy).toHaveBeenCalled();
+        });
+        // Test that the menu's focusCurrentChild method is called.
+        it("should call the menu's focusCurrentChild method", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "dynamic",
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Spy on the menu's focusCurrentChild method.
+          const spy = vi.spyOn(
+            menu.elements.submenuToggles[0].elements.controlledMenu,
+            "focusCurrentChild"
+          );
+
+          // Simulate the pointerenter event.
+          simulatePointerEvent(
+            "pointerenter",
+            menu.elements.submenuToggles[0].elements.controlledMenu.elements
+              .menuItems[1].dom.link
+          );
+
+          expect(spy).toHaveBeenCalled();
+        });
+        // Test that clearTimeout is called.
+        it("should call clearTimeout", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "dynamic",
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Spy on the menu item's clearTimeout method.
+          const spy = vi.spyOn(
+            menu.elements.submenuToggles[0].elements.controlledMenu,
+            "_clearTimeout"
+          );
+
+          // Simulate the pointerenter event.
+          simulatePointerEvent(
+            "pointerenter",
+            menu.elements.submenuToggles[0].elements.controlledMenu.elements
+              .menuItems[1].dom.link
+          );
+
+          expect(spy).toHaveBeenCalled();
+        });
+        // Test that preview is called after a delay.
+        it("should call preview after a delay", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "dynamic",
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Spy on the menu's preview method.
+          const spy = vi.spyOn(
+            menu.elements.submenuToggles[0].elements.controlledMenu.elements
+              .submenuToggles[0],
+            "preview"
+          );
+
+          // Simulate the pointerenter event.
+          simulatePointerEvent(
+            "pointerenter",
+            menu.elements.submenuToggles[0].elements.controlledMenu.elements
+              .menuItems[1].dom.link
+          );
+
+          // Advance the timers by the menu's enter delay.
+          vi.advanceTimersByTime(menu.enterDelay);
+
+          vi.waitFor(() => expect(spy).toHaveBeenCalled(), {
+            timeout: 10000,
+            interval: 10,
+          });
+        });
+        // Test that preview is called immediately when enterDelay is set to 0.
+        it("should call preview immediately when enterDelay is set to 0", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "dynamic",
+            enterDelay: 0,
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Spy on the menu's preview method.
+          const spy = vi.spyOn(
+            menu.elements.submenuToggles[0].elements.controlledMenu.elements
+              .submenuToggles[0],
+            "preview"
+          );
+
+          // Simulate the pointerenter event.
+          simulatePointerEvent(
+            "pointerenter",
+            menu.elements.submenuToggles[0].elements.controlledMenu.elements
+              .menuItems[1].dom.link
+          );
+
+          expect(spy).toHaveBeenCalled();
+        });
+      });
+      describe("if the menu item is a submenu item and the menu is the root menu with an open submenu", () => {
+        // Test that the menu's current event is set to mouse.
+        it("should set the menu's current event to mouse", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "dynamic",
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Simulate the pointerenter event.
+          simulatePointerEvent(
+            "pointerenter",
+            menu.elements.menuItems[2].dom.link
+          );
+
+          expect(menu.currentEvent).toBe("mouse");
+        });
+        // Test that the root menu's blurChildren method is called.
+        it("should call the root menu's blurChildren method", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "dynamic",
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Spy on the root menu's blurChildren method.
+          const spy = vi.spyOn(menu.elements.rootMenu, "blurChildren");
+
+          // Simulate the pointerenter event.
+          simulatePointerEvent(
+            "pointerenter",
+            menu.elements.menuItems[2].dom.link
+          );
+
+          expect(spy).toHaveBeenCalled();
+        });
+        // Test that the menu's focusCurrentChild method is called.
+        it("should call the menu's focusCurrentChild method", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "dynamic",
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Spy on the menu's focusCurrentChild method.
+          const spy = vi.spyOn(menu, "focusCurrentChild");
+
+          // Simulate the pointerenter event.
+          simulatePointerEvent(
+            "pointerenter",
+            menu.elements.menuItems[2].dom.link
+          );
+
+          expect(spy).toHaveBeenCalled();
+        });
+        // Test that clearTimeout is called.
+        it("should call clearTimeout", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "dynamic",
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Spy on the menu's clearTimeout method.
+          const spy = vi.spyOn(menu, "_clearTimeout");
+
+          // Simulate the pointerenter event.
+          simulatePointerEvent(
+            "pointerenter",
+            menu.elements.menuItems[2].dom.link
+          );
+
+          // Advance the timers by the menu's enter delay.
+          vi.advanceTimersByTime(menu.enterDelay);
+
+          expect(spy).toHaveBeenCalled();
+        });
+        // Test that preview is called after a delay.
+        it("should call preview after a delay", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "dynamic",
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Spy on the menu's preview method.
+          const spy = vi.spyOn(menu.elements.submenuToggles[1], "preview");
+
+          // Simulate the pointerenter event.
+          simulatePointerEvent(
+            "pointerenter",
+            menu.elements.menuItems[2].dom.link
+          );
+
+          // Advance the timers by the menu's enter delay.
+          vi.advanceTimersByTime(menu.enterDelay);
+
+          vi.waitFor(() => expect(spy).toHaveBeenCalled(), {
+            timeout: 10000,
+            interval: 10,
+          });
+        });
+        // Test that preview is called immediately when enterDelay is set to 0.
+        it("should call preview immediately when enterDelay is set to 0", () => {
+          // Create a new Treeview instance for testing.
+          const menu = new Treeview({
+            menuElement: document.querySelector("ul"),
+            submenuItemSelector: "li.dropdown",
+            containerElement: document.querySelector("nav"),
+            controllerElement: document.querySelector("button"),
+            hoverType: "dynamic",
+            enterDelay: 0,
+          });
+
+          menu.currentChild = 1;
+          menu.elements.submenuToggles[0].open();
+
+          // Spy on the menu's preview method.
+          const spy = vi.spyOn(menu.elements.submenuToggles[1], "preview");
+
+          // Simulate the pointerenter event.
+          simulatePointerEvent(
+            "pointerenter",
+            menu.elements.menuItems[2].dom.link
+          );
+
+          expect(spy).toHaveBeenCalled();
+        });
+      });
+    });
+    // Test pointerleave.
+    describe("pointerleave", () => {
+      describe("if the menu is not the root menu", () => {
+        describe("when a menu item is a submenu item", () => {
+          // Test that clearTimeout is called when a menu item is unhovered.
+          it("should call clearTimeout when a menu item is unhovered", () => {
+            // Create a new Treeview instance for testing.
+            const menu = new Treeview({
+              menuElement: document.querySelector("ul"),
+              submenuItemSelector: "li.dropdown",
+              containerElement: document.querySelector("nav"),
+              controllerElement: document.querySelector("button"),
+              hoverType: "dynamic",
+            });
+
+            menu.currentChild = 1;
+            menu.elements.submenuToggles[0].open();
+
+            // Spy on the menu's clearTimeout method.
+            const spy = vi.spyOn(
+              menu.elements.submenuToggles[0].elements.controlledMenu,
+              "_clearTimeout"
+            );
+
+            // Simulate the pointerleave event.
+            simulatePointerEvent(
+              "pointerleave",
+              menu.elements.submenuToggles[0].elements.controlledMenu.elements
+                .menuItems[1].dom.link
+            );
+
+            // Advance the timers by the menu's leave delay.
+            vi.advanceTimersByTime(menu.leaveDelay);
+
+            vi.waitFor(() => expect(spy).toHaveBeenCalled(), {
+              timeout: 10000,
+              interval: 10,
+            });
+          });
+          // Test that clearTimeout is not called when a menu item is unhovered and leaveDelay is set to 0.
+          it("should not call clearTimeout when a menu item is unhovered and leaveDelay is set to 0", () => {
+            // Create a new Treeview instance for testing.
+            const menu = new Treeview({
+              menuElement: document.querySelector("ul"),
+              submenuItemSelector: "li.dropdown",
+              containerElement: document.querySelector("nav"),
+              controllerElement: document.querySelector("button"),
+              hoverType: "dynamic",
+              leaveDelay: 0,
+            });
+
+            menu.currentChild = 1;
+            menu.elements.submenuToggles[0].open();
+
+            // Spy on the menu's clearTimeout method.
+            const spy = vi.spyOn(
+              menu.elements.submenuToggles[0].elements.controlledMenu,
+              "_clearTimeout"
+            );
+
+            // Simulate the pointerleave event.
+            simulatePointerEvent(
+              "pointerleave",
+              menu.elements.submenuToggles[0].elements.controlledMenu.elements
+                .menuItems[1].dom.link
+            );
+
+            expect(spy).not.toHaveBeenCalled();
+          });
+        });
+      });
+    });
+  });
+});

--- a/tests/menus/Treeview/protected.test.js
+++ b/tests/menus/Treeview/protected.test.js
@@ -47,14 +47,4 @@ describe("Treeview protected methods", () => {
       );
     });
   });
-
-  // Test Treeview _handleHover().
-  describe("_handleHover", () => {
-    // Test that Treeview implements the BaseMenu _handleHover() method.
-    it("should implement the BaseMenu _handleHover() method", () => {
-      expect(Treeview.prototype._handleHover).toBe(
-        BaseMenu.prototype._handleHover
-      );
-    });
-  });
 });


### PR DESCRIPTION
## Description
Treeviews are pretty terrible to hover over so it needs to be tweaked a little to not be unusable. 

## Related Issues
See #315
