### PR TITLE
Handle menu items that are not `<a>` tags

### DIFF
--- a/src/_baseMenu.js
+++ b/src/_baseMenu.js
@@ -1377,7 +1377,7 @@ class BaseMenu {
    */
   _handleFocus() {
     this.elements.menuItems.forEach((menuItem, index) => {
-      menuItem.dom.link.addEventListener("focus", () => {
+      menuItem.dom.link?.addEventListener("focus", () => {
         this.focusState = "self";
         this.currentChild = index;
       });
@@ -1436,7 +1436,7 @@ class BaseMenu {
 
     this.elements.menuItems.forEach((item, index) => {
       // Properly focus the current menu item.
-      item.dom.link.addEventListener(
+      item.dom.link?.addEventListener(
         "pointerdown",
         () => {
           this.currentEvent = "mouse";
@@ -1534,7 +1534,7 @@ class BaseMenu {
    */
   _handleHover() {
     this.elements.menuItems.forEach((menuItem, index) => {
-      menuItem.dom.link.addEventListener("pointerenter", (event) => {
+      menuItem.dom.link?.addEventListener("pointerenter", (event) => {
         // Exit out of the event if it was not made by a mouse.
         if (event.pointerType === "pen" || event.pointerType === "touch") {
           return;

--- a/src/topLinkDisclosureMenu.js
+++ b/src/topLinkDisclosureMenu.js
@@ -443,7 +443,7 @@ class TopLinkDisclosureMenu extends BaseMenu {
    */
   _handleHover() {
     this.elements.menuItems.forEach((menuItem, index) => {
-      menuItem.dom.link.addEventListener("pointerenter", (event) => {
+      menuItem.dom.link?.addEventListener("pointerenter", (event) => {
         // Exit out of the event if it was not made by a mouse.
         if (event.pointerType === "pen" || event.pointerType === "touch") {
           return;

--- a/src/treeview.js
+++ b/src/treeview.js
@@ -210,7 +210,7 @@ class Treeview extends BaseMenu {
    */
   _handleHover() {
     this.elements.menuItems.forEach((menuItem, index) => {
-      menuItem.dom.link.addEventListener("pointerenter", (event) => {
+      menuItem.dom.link?.addEventListener("pointerenter", (event) => {
         // Exit out of the event if it was not made by a mouse.
         if (event.pointerType === "pen" || event.pointerType === "touch") {
           return;


### PR DESCRIPTION
Accessible menus don't necessarily consist of `<a>` elements only. The active item might be a `<strong>` element and we have one case where it is a `<button>` element. In these cases, there will be a `TypeError: null is not an object (evaluating 'e.dom.link.addEventListener')` error:

<img width="469" alt="" src="https://github.com/user-attachments/assets/20cdf867-7776-419a-bf01-15d41669dce5" />

This PR fixes this by changing `dom.link.addEventListener` to `dom.link?.addEventListener`.