### PR TITLE
fix: do not handle Enter key

### DIFF
--- a/demo/menus.js
+++ b/demo/menus.js
@@ -4,14 +4,14 @@ export const singleLevel =
 <nav id="example-menu" aria-label="example" aria-describedby="disclaimer">
   <button id="example-toggle" class="menu-toggle" aria-label="Example menu">☰</button>
   <ul class="menu">
-    <li class="menu-item"><a class="menu-link" href="#">About</a></li>
-    <li class="menu-item"><a class="menu-link" href="#">Mammals</a></li>
-    <li class="menu-item"><a class="menu-link" href="#">Reptiles</a></li>
-    <li class="menu-item"><a class="menu-link" href="#">Amphibians</a></li>
-    <li class="menu-item"><a class="menu-link" href="#">Birds</a></li>
-    <li class="menu-item"><a class="menu-link" href="#">Fish</a></li>
-    <li class="menu-item"><a class="menu-link" href="#">Map</a></li>
-    <li class="menu-item"><a class="menu-link" href="#">Contact</a></li>
+    <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
+    <li class="menu-item"><a class="menu-link" href="#Mammals">Mammals</a></li>
+    <li class="menu-item"><a class="menu-link" href="#Reptiles">Reptiles</a></li>
+    <li class="menu-item"><a class="menu-link" href="#Amphibians">Amphibians</a></li>
+    <li class="menu-item"><a class="menu-link" href="#Birds">Birds</a></li>
+    <li class="menu-item"><a class="menu-link" href="#Fish">Fish</a></li>
+    <li class="menu-item"><a class="menu-link" href="#Map">Map</a></li>
+    <li class="menu-item"><a class="menu-link" href="#Contact">Contact</a></li>
   </ul>
 </nav>
 `;
@@ -22,63 +22,63 @@ export const twoLevel =
 <nav id="example-menu" aria-label="example" aria-describedby="disclaimer">
   <button id="example-toggle" class="menu-toggle" aria-label="Example menu">☰</button>
   <ul class="menu">
-    <li class="menu-item"><a class="menu-link" href="#">About</a></li>
+    <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
     <li class="menu-item dropdown">
-      <a class="menu-link dropdown-toggle" href="#">Mammals</a>
+      <a class="menu-link dropdown-toggle" href="#Mammals">Mammals</a>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Wild</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Domesticated</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Food</a></li>
-      </ul>
-    </li>
-    <li class="menu-item dropdown">
-      <a class="menu-link dropdown-toggle" href="#">Reptiles</a>
-      <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Wild</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Domesticated</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Food</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Wild">Wild</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Domesticated">Domesticated</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Food">Food</a></li>
       </ul>
     </li>
     <li class="menu-item dropdown">
-      <a class="menu-link dropdown-toggle" href="#">Amphibians</a>
+      <a class="menu-link dropdown-toggle" href="#Reptiles">Reptiles</a>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Wild</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Domesticated</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Food</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Wild">Wild</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Domesticated">Domesticated</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Food">Food</a></li>
+      </ul>
+    </li>
+    <li class="menu-item dropdown">
+      <a class="menu-link dropdown-toggle" href="#Amphibians">Amphibians</a>
+      <ul class="dropdown-menu">
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Wild">Wild</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Domesticated">Domesticated</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Food">Food</a></li>
       </ul>
     </li>
     <li class="menu-item dropdown dropdown-left">
-      <a class="menu-link dropdown-toggle" href="#">Birds</a>
+      <a class="menu-link dropdown-toggle" href="#Birds">Birds</a>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Wild</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Domesticated</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Food</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Wild">Wild</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Domesticated">Domesticated</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Food">Food</a></li>
       </ul>
     </li>
     <li class="menu-item dropdown dropdown-left">
-      <a class="menu-link dropdown-toggle" href="#">Fish</a>
+      <a class="menu-link dropdown-toggle" href="#Fish">Fish</a>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Wild</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Domesticated</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Food</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Wild">Wild</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Domesticated">Domesticated</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Food">Food</a></li>
       </ul>
     </li>
-    <li class="menu-item"><a class="menu-link" href="#">Map</a></li>
+    <li class="menu-item"><a class="menu-link" href="#Map">Map</a></li>
     <li class="menu-item dropdown dropdown-left">
-      <a class="menu-link dropdown-toggle" href="#">Contact</a>
+      <a class="menu-link dropdown-toggle" href="#Contact">Contact</a>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">Email</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Socials</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Email">Email</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Socials">Socials</a></li>
       </ul>
     </li>
   </ul>
@@ -91,63 +91,63 @@ export const twoLevelDisclosure =
 <nav id="example-menu" aria-label="example" aria-describedby="disclaimer">
   <button id="example-toggle" class="menu-toggle" aria-label="Example menu">☰</button>
   <ul class="menu">
-    <li class="menu-item"><a class="menu-link" href="#">About</a></li>
+    <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
     <li class="menu-item dropdown">
       <button class="menu-link dropdown-toggle">Mammals</button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Wild</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Domesticated</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Food</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Wild">Wild</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Domesticated">Domesticated</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Food">Food</a></li>
       </ul>
     </li>
     <li class="menu-item dropdown">
       <button class="menu-link dropdown-toggle">Reptiles</button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Wild</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Domesticated</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Food</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Wild">Wild</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Domesticated">Domesticated</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Food">Food</a></li>
       </ul>
     </li>
     <li class="menu-item dropdown">
       <button class="menu-link dropdown-toggle">Amphibians</button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Wild</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Domesticated</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Food</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Wild">Wild</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Domesticated">Domesticated</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Food">Food</a></li>
       </ul>
     </li>
     <li class="menu-item dropdown dropdown-left">
       <button class="menu-link dropdown-toggle">Birds</button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Wild</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Domesticated</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Food</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Wild">Wild</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Domesticated">Domesticated</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Food">Food</a></li>
       </ul>
     </li>
     <li class="menu-item dropdown dropdown-left">
       <button class="menu-link dropdown-toggle">Fish</button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Wild</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Domesticated</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Food</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Wild">Wild</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Domesticated">Domesticated</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Food">Food</a></li>
       </ul>
     </li>
-    <li class="menu-item"><a class="menu-link" href="#">Map</a></li>
+    <li class="menu-item"><a class="menu-link" href="#Map">Map</a></li>
     <li class="menu-item dropdown dropdown-left">
       <button class="menu-link dropdown-toggle">Contact</button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">Email</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Socials</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Email">Email</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Socials">Socials</a></li>
       </ul>
     </li>
   </ul>
@@ -160,69 +160,69 @@ export const twoLevelDisclosureTopLink =
 <nav id="example-menu"  aria-label="example" aria-describedby="disclaimer">
   <button id="example-toggle" class="menu-toggle" aria-label="Example menu">☰</button>
   <ul class="menu">
-    <li class="menu-item"><a class="menu-link" href="#">About</a></li>
+    <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
     <li class="menu-item dropdown">
-      <a class="menu-link" href="#">Mammals</a>
+      <a class="menu-link" href="#Mammals">Mammals</a>
       <button class="dropdown-toggle" aria-label="Mammals submenu"></button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Wild</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Domesticated</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Food</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Wild">Wild</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Domesticated">Domesticated</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Food">Food</a></li>
       </ul>
     </li>
     <li class="menu-item dropdown">
-      <a class="menu-link" href="#">Reptiles</a>
+      <a class="menu-link" href="#Reptiles">Reptiles</a>
       <button class="dropdown-toggle" aria-label="Reptiles submenu"></button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Wild</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Domesticated</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Food</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Wild">Wild</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Domesticated">Domesticated</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Food">Food</a></li>
       </ul>
     </li>
     <li class="menu-item dropdown">
-      <a class="menu-link" href="#">Amphibians</a>
+      <a class="menu-link" href="#Amphibians">Amphibians</a>
       <button class="dropdown-toggle" aria-label="Amphibians submenu"></button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Wild</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Domesticated</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Food</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Wild">Wild</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Domesticated">Domesticated</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Food">Food</a></li>
       </ul>
     </li>
     <li class="menu-item dropdown dropdown-left">
-      <a class="menu-link" href="#">Birds</a>
+      <a class="menu-link" href="#Birds">Birds</a>
       <button class="dropdown-toggle" aria-label="Birds submenu"></button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Wild</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Domesticated</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Food</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Wild">Wild</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Domesticated">Domesticated</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Food">Food</a></li>
       </ul>
     </li>
     <li class="menu-item dropdown dropdown-left">
-      <a class="menu-link" href="#">Fish</a>
+      <a class="menu-link" href="#Fish">Fish</a>
       <button class="dropdown-toggle" aria-label="Fish submenu"></button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Wild</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Domesticated</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Food</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Wild">Wild</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Domesticated">Domesticated</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Food">Food</a></li>
       </ul>
     </li>
-    <li class="menu-item"><a class="menu-link" href="#">Map</a></li>
+    <li class="menu-item"><a class="menu-link" href="#Map">Map</a></li>
     <li class="menu-item dropdown dropdown-left">
-      <a class="menu-link" href="#">Contact</a>
+      <a class="menu-link" href="#Contact">Contact</a>
       <button class="dropdown-toggle" aria-label="Contact submenu"></button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">Email</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Socials</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Email">Email</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Socials">Socials</a></li>
       </ul>
     </li>
   </ul>
@@ -235,69 +235,69 @@ export const twoLevelDisclosureTopLinkNoButtons =
 <nav id="example-menu"  aria-label="example" aria-describedby="disclaimer">
   <button id="example-toggle" class="menu-toggle" aria-label="Example menu">☰</button>
   <ul class="menu">
-    <li class="menu-item"><a class="menu-link" href="#">About</a></li>
+    <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
     <li class="menu-item dropdown">
-      <a class="menu-link" href="#">Mammals</a>
-      <a class="dropdown-toggle" href="#" aria-label="Mammals submenu"></a>
+      <a class="menu-link" href="#Mammals">Mammals</a>
+      <a class="dropdown-toggle" href="#aria" aria-label="Mammals submenu"></a>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Wild</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Domesticated</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Food</a></li>
-      </ul>
-    </li>
-    <li class="menu-item dropdown">
-      <a class="menu-link" href="#">Reptiles</a>
-      <a class="dropdown-toggle" href="#" aria-label="Reptiles submenu"></a>
-      <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Wild</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Domesticated</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Food</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Wild">Wild</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Domesticated">Domesticated</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Food">Food</a></li>
       </ul>
     </li>
     <li class="menu-item dropdown">
-      <a class="menu-link" href="#">Amphibians</a>
-      <a class="dropdown-toggle" href="#" aria-label="Amphibians submenu"></a>
+      <a class="menu-link" href="#Reptiles">Reptiles</a>
+      <a class="dropdown-toggle" href="#aria" aria-label="Reptiles submenu"></a>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Wild</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Domesticated</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Food</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Wild">Wild</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Domesticated">Domesticated</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Food">Food</a></li>
+      </ul>
+    </li>
+    <li class="menu-item dropdown">
+      <a class="menu-link" href="#Amphibians">Amphibians</a>
+      <a class="dropdown-toggle" href="#aria" aria-label="Amphibians submenu"></a>
+      <ul class="dropdown-menu">
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Wild">Wild</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Domesticated">Domesticated</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Food">Food</a></li>
       </ul>
     </li>
     <li class="menu-item dropdown dropdown-left">
-      <a class="menu-link" href="#">Birds</a>
-      <a class="dropdown-toggle" href="#" aria-label="Birds submenu"></a>
+      <a class="menu-link" href="#Birds">Birds</a>
+      <a class="dropdown-toggle" href="#aria" aria-label="Birds submenu"></a>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Wild</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Domesticated</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Food</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Wild">Wild</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Domesticated">Domesticated</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Food">Food</a></li>
       </ul>
     </li>
     <li class="menu-item dropdown dropdown-left">
-      <a class="menu-link" href="#">Fish</a>
-      <a class="dropdown-toggle" href="#" aria-label="Fish submenu"></a>
+      <a class="menu-link" href="#Fish">Fish</a>
+      <a class="dropdown-toggle" href="#aria" aria-label="Fish submenu"></a>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Wild</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Domesticated</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Food</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Wild">Wild</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Domesticated">Domesticated</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Food">Food</a></li>
       </ul>
     </li>
-    <li class="menu-item"><a class="menu-link" href="#">Map</a></li>
+    <li class="menu-item"><a class="menu-link" href="#Map">Map</a></li>
     <li class="menu-item dropdown dropdown-left">
-      <a class="menu-link" href="#">Contact</a>
-      <a class="dropdown-toggle" href="#" aria-label="Contact submenu"></a>
+      <a class="menu-link" href="#Contact">Contact</a>
+      <a class="dropdown-toggle" href="#aria" aria-label="Contact submenu"></a>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">Email</a></li>
-        <li class="menu-item"><a class="menu-link" href="#">Socials</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Email">Email</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Socials">Socials</a></li>
       </ul>
     </li>
   </ul>
@@ -310,168 +310,168 @@ export const threeLevel =
 <nav id="example-menu"  aria-label="example" aria-describedby="disclaimer">
   <button id="example-toggle" class="menu-toggle" aria-label="Example menu">☰</button>
   <ul class="menu">
-    <li class="menu-item"><a class="menu-link" href="#">About</a></li>
+    <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
     <li class="menu-item dropdown">
-      <a class="menu-link dropdown-toggle" href="#">Mammals</a>
+      <a class="menu-link dropdown-toggle" href="#Mammals">Mammals</a>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Wild</a>
+          <a class="menu-link dropdown-toggle" href="#Wild">Wild</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Bears</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Lions</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Wolves</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Bears">Bears</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Lions">Lions</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Wolves">Wolves</a></li>
           </ul>
         </li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Domesticated</a>
+          <a class="menu-link dropdown-toggle" href="#Domesticated">Domesticated</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Cats</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Dogs</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Horses</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Cats">Cats</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Dogs">Dogs</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Horses">Horses</a></li>
           </ul>
         </li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Food</a>
+          <a class="menu-link dropdown-toggle" href="#Food">Food</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Can Eat</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Can't Eat</a></li>
-          </ul>
-        </li>
-      </ul>
-    </li>
-    <li class="menu-item dropdown">
-      <a class="menu-link dropdown-toggle" href="#">Reptiles</a>
-      <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
-        <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Wild</a>
-          <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Snakes</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Lizards</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Turtles</a></li>
-          </ul>
-        </li>
-        <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Domesticated</a>
-          <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Geckos</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Tortoises</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Iguanas</a></li>
-          </ul>
-        </li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
-        <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Food</a>
-          <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Can Eat</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Can't Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can't Eat</a></li>
           </ul>
         </li>
       </ul>
     </li>
     <li class="menu-item dropdown">
-      <a class="menu-link dropdown-toggle" href="#">Amphibians</a>
+      <a class="menu-link dropdown-toggle" href="#Reptiles">Reptiles</a>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Wild</a>
+          <a class="menu-link dropdown-toggle" href="#Wild">Wild</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Frogs</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Toads</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Salamanders</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Snakes">Snakes</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Lizards">Lizards</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Turtles">Turtles</a></li>
           </ul>
         </li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Domesticated</a>
+          <a class="menu-link dropdown-toggle" href="#Domesticated">Domesticated</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Axolotls</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Newts</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Frogs</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Geckos">Geckos</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Tortoises">Tortoises</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Iguanas">Iguanas</a></li>
           </ul>
         </li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Food</a>
+          <a class="menu-link dropdown-toggle" href="#Food">Food</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Can Eat</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Can't Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can't Eat</a></li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li class="menu-item dropdown">
+      <a class="menu-link dropdown-toggle" href="#Amphibians">Amphibians</a>
+      <ul class="dropdown-menu">
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
+        <li class="menu-item dropdown">
+          <a class="menu-link dropdown-toggle" href="#Wild">Wild</a>
+          <ul class="dropdown-menu">
+            <li class="menu-item"><a class="menu-link" href="#Frogs">Frogs</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Toads">Toads</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Salamanders">Salamanders</a></li>
+          </ul>
+        </li>
+        <li class="menu-item dropdown">
+          <a class="menu-link dropdown-toggle" href="#Domesticated">Domesticated</a>
+          <ul class="dropdown-menu">
+            <li class="menu-item"><a class="menu-link" href="#Axolotls">Axolotls</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Newts">Newts</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Frogs">Frogs</a></li>
+          </ul>
+        </li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
+        <li class="menu-item dropdown">
+          <a class="menu-link dropdown-toggle" href="#Food">Food</a>
+          <ul class="dropdown-menu">
+            <li class="menu-item"><a class="menu-link" href="#Can">Can Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can't Eat</a></li>
           </ul>
         </li>
       </ul>
     </li>
     <li class="menu-item dropdown dropdown-left">
-      <a class="menu-link dropdown-toggle" href="#">Birds</a>
+      <a class="menu-link dropdown-toggle" href="#Birds">Birds</a>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Wild</a>
+          <a class="menu-link dropdown-toggle" href="#Wild">Wild</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Eagles</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Hawks</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Owls</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Eagles">Eagles</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Hawks">Hawks</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Owls">Owls</a></li>
           </ul>
         </li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Domesticated</a>
+          <a class="menu-link dropdown-toggle" href="#Domesticated">Domesticated</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Parakeets</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Pigeons</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Chickens</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Parakeets">Parakeets</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Pigeons">Pigeons</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Chickens">Chickens</a></li>
           </ul>
         </li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Food</a>
+          <a class="menu-link dropdown-toggle" href="#Food">Food</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Can Eat</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Can't Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can't Eat</a></li>
           </ul>
         </li>
       </ul>
     </li>
     <li class="menu-item dropdown dropdown-left">
-      <a class="menu-link dropdown-toggle" href="#">Fish</a>
+      <a class="menu-link dropdown-toggle" href="#Fish">Fish</a>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Wild</a>
+          <a class="menu-link dropdown-toggle" href="#Wild">Wild</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Trout</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Carp</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Perch</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Trout">Trout</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Carp">Carp</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Perch">Perch</a></li>
           </ul>
         </li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Domesticated</a>
+          <a class="menu-link dropdown-toggle" href="#Domesticated">Domesticated</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Goldfish</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Koi</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Betta</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Goldfish">Goldfish</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Koi">Koi</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Betta">Betta</a></li>
           </ul>
         </li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Food</a>
+          <a class="menu-link dropdown-toggle" href="#Food">Food</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Can Eat</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Can't Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can't Eat</a></li>
           </ul>
         </li>
       </ul>
     </li>
-    <li class="menu-item"><a class="menu-link" href="#">Map</a></li>
+    <li class="menu-item"><a class="menu-link" href="#Map">Map</a></li>
     <li class="menu-item dropdown dropdown-left">
-      <a class="menu-link dropdown-toggle" href="#">Contact</a>
+      <a class="menu-link dropdown-toggle" href="#Contact">Contact</a>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">Email</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Email">Email</a></li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Socials</a>
+          <a class="menu-link dropdown-toggle" href="#Socials">Socials</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Twitter</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Facebook</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Instagram</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Twitter">Twitter</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Facebook">Facebook</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Instagram">Instagram</a></li>
           </ul>
         </li>
       </ul>
@@ -486,33 +486,33 @@ export const threeLevelDisclosure =
 <nav id="example-menu"  aria-label="example" aria-describedby="disclaimer">
   <button id="example-toggle" class="menu-toggle" aria-label="Example menu">☰</button>
   <ul class="menu">
-    <li class="menu-item"><a class="menu-link" href="#">About</a></li>
+    <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
     <li class="menu-item dropdown">
       <button class="menu-link dropdown-toggle">Mammals</button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
         <li class="menu-item dropdown">
           <button class="menu-link dropdown-toggle">Wild</button>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Bears</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Lions</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Wolves</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Bears">Bears</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Lions">Lions</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Wolves">Wolves</a></li>
           </ul>
         </li>
         <li class="menu-item dropdown">
           <button class="menu-link dropdown-toggle">Domesticated</button>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Cats</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Dogs</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Horses</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Cats">Cats</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Dogs">Dogs</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Horses">Horses</a></li>
           </ul>
         </li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
         <li class="menu-item dropdown">
           <button class="menu-link dropdown-toggle">Food</button>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Can Eat</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Can't Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can't Eat</a></li>
           </ul>
         </li>
       </ul>
@@ -520,29 +520,29 @@ export const threeLevelDisclosure =
     <li class="menu-item dropdown">
       <button class="menu-link dropdown-toggle">Reptiles</button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
         <li class="menu-item dropdown">
           <button class="menu-link dropdown-toggle">Wild</button>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Snakes</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Lizards</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Turtles</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Snakes">Snakes</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Lizards">Lizards</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Turtles">Turtles</a></li>
           </ul>
         </li>
         <li class="menu-item dropdown">
           <button class="menu-link dropdown-toggle">Domesticated</button>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Geckos</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Tortoises</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Iguanas</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Geckos">Geckos</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Tortoises">Tortoises</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Iguanas">Iguanas</a></li>
           </ul>
         </li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
         <li class="menu-item dropdown">
           <button class="menu-link dropdown-toggle">Food</button>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Can Eat</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Can't Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can't Eat</a></li>
           </ul>
         </li>
       </ul>
@@ -550,29 +550,29 @@ export const threeLevelDisclosure =
     <li class="menu-item dropdown">
       <button class="menu-link dropdown-toggle">Amphibians</button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
         <li class="menu-item dropdown">
           <button class="menu-link dropdown-toggle">Wild</button>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Frogs</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Toads</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Salamanders</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Frogs">Frogs</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Toads">Toads</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Salamanders">Salamanders</a></li>
           </ul>
         </li>
         <li class="menu-item dropdown">
           <button class="menu-link dropdown-toggle">Domesticated</button>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Axolotls</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Newts</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Frogs</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Axolotls">Axolotls</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Newts">Newts</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Frogs">Frogs</a></li>
           </ul>
         </li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
         <li class="menu-item dropdown">
           <button class="menu-link dropdown-toggle">Food</button>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Can Eat</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Can't Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can't Eat</a></li>
           </ul>
         </li>
       </ul>
@@ -580,29 +580,29 @@ export const threeLevelDisclosure =
     <li class="menu-item dropdown dropdown-left">
       <button class="menu-link dropdown-toggle">Birds</button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
         <li class="menu-item dropdown">
           <button class="menu-link dropdown-toggle">Wild</button>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Eagles</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Hawks</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Owls</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Eagles">Eagles</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Hawks">Hawks</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Owls">Owls</a></li>
           </ul>
         </li>
         <li class="menu-item dropdown">
           <button class="menu-link dropdown-toggle">Domesticated</button>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Parakeets</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Pigeons</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Chickens</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Parakeets">Parakeets</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Pigeons">Pigeons</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Chickens">Chickens</a></li>
           </ul>
         </li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
         <li class="menu-item dropdown">
           <button class="menu-link dropdown-toggle">Food</button>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Can Eat</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Can't Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can't Eat</a></li>
           </ul>
         </li>
       </ul>
@@ -610,44 +610,44 @@ export const threeLevelDisclosure =
     <li class="menu-item dropdown dropdown-left">
       <button class="menu-link dropdown-toggle">Fish</button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
         <li class="menu-item dropdown">
           <button class="menu-link dropdown-toggle">Wild</button>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Trout</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Carp</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Perch</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Trout">Trout</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Carp">Carp</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Perch">Perch</a></li>
           </ul>
         </li>
         <li class="menu-item dropdown">
           <button class="menu-link dropdown-toggle">Domesticated</button>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Goldfish</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Koi</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Betta</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Goldfish">Goldfish</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Koi">Koi</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Betta">Betta</a></li>
           </ul>
         </li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
         <li class="menu-item dropdown">
           <button class="menu-link dropdown-toggle">Food</button>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Can Eat</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Can't Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can't Eat</a></li>
           </ul>
         </li>
       </ul>
     </li>
-    <li class="menu-item"><a class="menu-link" href="#">Map</a></li>
+    <li class="menu-item"><a class="menu-link" href="#Map">Map</a></li>
     <li class="menu-item dropdown dropdown-left">
       <button class="menu-link dropdown-toggle">Contact</button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">Email</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Email">Email</a></li>
         <li class="menu-item dropdown">
           <button class="menu-link dropdown-toggle">Socials</button>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Twitter</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Facebook</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Instagram</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Twitter">Twitter</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Facebook">Facebook</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Instagram">Instagram</a></li>
           </ul>
         </li>
       </ul>
@@ -662,174 +662,174 @@ export const threeLevelDisclosureTopLink =
 <nav id="example-menu"  aria-label="example" aria-describedby="disclaimer">
   <button id="example-toggle" class="menu-toggle" aria-label="Example menu">☰</button>
   <ul class="menu">
-    <li class="menu-item"><a class="menu-link" href="#">About</a></li>
+    <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
     <li class="menu-item dropdown">
-      <a class="menu-link" href="#">Mammals</a>
+      <a class="menu-link" href="#Mammals">Mammals</a>
       <button class="dropdown-toggle" aria-label="Mammals submenu"></button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Wild</a>
+          <a class="menu-link dropdown-toggle" href="#Wild">Wild</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Bears</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Lions</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Wolves</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Bears">Bears</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Lions">Lions</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Wolves">Wolves</a></li>
           </ul>
         </li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Domesticated</a>
+          <a class="menu-link dropdown-toggle" href="#Domesticated">Domesticated</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Cats</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Dogs</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Horses</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Cats">Cats</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Dogs">Dogs</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Horses">Horses</a></li>
           </ul>
         </li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Food</a>
+          <a class="menu-link dropdown-toggle" href="#Food">Food</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Can Eat</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Can't Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can't Eat</a></li>
           </ul>
         </li>
       </ul>
     </li>
     <li class="menu-item dropdown">
-      <a class="menu-link" href="#">Reptiles</a>
+      <a class="menu-link" href="#Reptiles">Reptiles</a>
       <button class="dropdown-toggle" aria-label="Reptiles submenu"></button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Wild</a>
+          <a class="menu-link dropdown-toggle" href="#Wild">Wild</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Snakes</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Lizards</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Turtles</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Snakes">Snakes</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Lizards">Lizards</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Turtles">Turtles</a></li>
           </ul>
         </li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Domesticated</a>
+          <a class="menu-link dropdown-toggle" href="#Domesticated">Domesticated</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Geckos</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Tortoises</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Iguanas</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Geckos">Geckos</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Tortoises">Tortoises</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Iguanas">Iguanas</a></li>
           </ul>
         </li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Food</a>
+          <a class="menu-link dropdown-toggle" href="#Food">Food</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Can Eat</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Can't Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can't Eat</a></li>
           </ul>
         </li>
       </ul>
     </li>
     <li class="menu-item dropdown">
-      <a class="menu-link" href="#">Amphibians</a>
+      <a class="menu-link" href="#Amphibians">Amphibians</a>
       <button class="dropdown-toggle" aria-label="Amphibians submenu"></button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Wild</a>
+          <a class="menu-link dropdown-toggle" href="#Wild">Wild</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Frogs</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Toads</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Salamanders</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Frogs">Frogs</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Toads">Toads</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Salamanders">Salamanders</a></li>
           </ul>
         </li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Domesticated</a>
+          <a class="menu-link dropdown-toggle" href="#Domesticated">Domesticated</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Axolotls</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Newts</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Frogs</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Axolotls">Axolotls</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Newts">Newts</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Frogs">Frogs</a></li>
           </ul>
         </li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Food</a>
+          <a class="menu-link dropdown-toggle" href="#Food">Food</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Can Eat</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Can't Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can't Eat</a></li>
           </ul>
         </li>
       </ul>
     </li>
     <li class="menu-item dropdown dropdown-left">
-      <a class="menu-link" href="#">Birds</a>
+      <a class="menu-link" href="#Birds">Birds</a>
       <button class="dropdown-toggle" aria-label="Birds submenu"></button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Wild</a>
+          <a class="menu-link dropdown-toggle" href="#Wild">Wild</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Eagles</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Hawks</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Owls</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Eagles">Eagles</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Hawks">Hawks</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Owls">Owls</a></li>
           </ul>
         </li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Domesticated</a>
+          <a class="menu-link dropdown-toggle" href="#Domesticated">Domesticated</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Parakeets</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Pigeons</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Chickens</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Parakeets">Parakeets</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Pigeons">Pigeons</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Chickens">Chickens</a></li>
           </ul>
         </li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Food</a>
+          <a class="menu-link dropdown-toggle" href="#Food">Food</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Can Eat</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Can't Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can't Eat</a></li>
           </ul>
         </li>
       </ul>
     </li>
     <li class="menu-item dropdown dropdown-left">
-      <a class="menu-link" href="#">Fish</a>
+      <a class="menu-link" href="#Fish">Fish</a>
       <button class="dropdown-toggle" aria-label="Fish submenu"></button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">About</a></li>
+        <li class="menu-item"><a class="menu-link" href="#About">About</a></li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Wild</a>
+          <a class="menu-link dropdown-toggle" href="#Wild">Wild</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Trout</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Carp</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Perch</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Trout">Trout</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Carp">Carp</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Perch">Perch</a></li>
           </ul>
         </li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Domesticated</a>
+          <a class="menu-link dropdown-toggle" href="#Domesticated">Domesticated</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Goldfish</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Koi</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Betta</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Goldfish">Goldfish</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Koi">Koi</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Betta">Betta</a></li>
           </ul>
         </li>
-        <li class="menu-item"><a class="menu-link" href="#">Habitats</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Habitats">Habitats</a></li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Food</a>
+          <a class="menu-link dropdown-toggle" href="#Food">Food</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Can Eat</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Can't Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can Eat</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Can">Can't Eat</a></li>
           </ul>
         </li>
       </ul>
     </li>
-    <li class="menu-item"><a class="menu-link" href="#">Map</a></li>
+    <li class="menu-item"><a class="menu-link" href="#Map">Map</a></li>
     <li class="menu-item dropdown dropdown-left">
-      <a class="menu-link" href="#">Contact</a>
+      <a class="menu-link" href="#Contact">Contact</a>
       <button class="dropdown-toggle" aria-label="Contact submenu"></button>
       <ul class="dropdown-menu">
-        <li class="menu-item"><a class="menu-link" href="#">Email</a></li>
+        <li class="menu-item"><a class="menu-link" href="#Email">Email</a></li>
         <li class="menu-item dropdown">
-          <a class="menu-link dropdown-toggle" href="#">Socials</a>
+          <a class="menu-link dropdown-toggle" href="#Socials">Socials</a>
           <ul class="dropdown-menu">
-            <li class="menu-item"><a class="menu-link" href="#">Twitter</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Facebook</a></li>
-            <li class="menu-item"><a class="menu-link" href="#">Instagram</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Twitter">Twitter</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Facebook">Facebook</a></li>
+            <li class="menu-item"><a class="menu-link" href="#Instagram">Instagram</a></li>
           </ul>
         </li>
       </ul>

--- a/src/disclosureMenu.js
+++ b/src/disclosureMenu.js
@@ -272,7 +272,7 @@ class DisclosureMenu extends BaseMenu {
 
       // Prevent default event actions if we're handling the keyup event.
       if (this.focusState === "self") {
-        const keys = ["Space", "Enter"];
+        const submenuKeys = ["Space", "Enter"];
         const controllerKeys = ["Escape"];
         const parentKeys = ["Escape"];
         const optionalKeys = [
@@ -284,7 +284,12 @@ class DisclosureMenu extends BaseMenu {
           "End",
         ];
 
-        if (keys.includes(key)) {
+        if (key === "Space") {
+          preventEvent(event);
+        } else if (
+          this.currentMenuItem.isSubmenuItem &&
+          submenuKeys.includes(key)
+        ) {
           preventEvent(event);
         } else if (this.optionalKeySupport && optionalKeys.includes(key)) {
           preventEvent(event);
@@ -328,20 +333,21 @@ class DisclosureMenu extends BaseMenu {
       const key = keyPress(event);
 
       if (this.focusState === "self") {
-        if (key === "Space" || key === "Enter") {
+        if (
+          (key === "Space" || key === "Enter") &&
+          this.currentMenuItem.isSubmenuItem
+        ) {
           // Hitting Space or Enter:
           // - If focus is on a disclosure button, activates the button, which toggles the visibility of the dropdown.
-          if (this.currentMenuItem.isSubmenuItem) {
-            preventEvent(event);
+          preventEvent(event);
 
-            if (this.currentMenuItem.elements.toggle.isOpen) {
-              this.currentMenuItem.elements.toggle.close();
-            } else {
-              this.currentMenuItem.elements.toggle.preview();
-            }
+          if (this.currentMenuItem.elements.toggle.isOpen) {
+            this.currentMenuItem.elements.toggle.close();
           } else {
-            this.currentMenuItem.dom.link.click();
+            this.currentMenuItem.elements.toggle.preview();
           }
+        } else if (key === "Space") {
+          this.currentMenuItem.dom.link.click();
         } else if (key === "Escape") {
           // Hitting Escape
           // - If a dropdown is open, closes it.

--- a/src/disclosureMenu.js
+++ b/src/disclosureMenu.js
@@ -272,7 +272,8 @@ class DisclosureMenu extends BaseMenu {
 
       // Prevent default event actions if we're handling the keyup event.
       if (this.focusState === "self") {
-        const submenuKeys = ["Space", "Enter"];
+        const keys = ["Space"];
+        const submenuKeys = ["Enter"];
         const controllerKeys = ["Escape"];
         const parentKeys = ["Escape"];
         const optionalKeys = [
@@ -284,7 +285,7 @@ class DisclosureMenu extends BaseMenu {
           "End",
         ];
 
-        if (key === "Space") {
+        if (keys.includes(key)) {
           preventEvent(event);
         } else if (
           this.currentMenuItem.isSubmenuItem &&

--- a/src/menubar.js
+++ b/src/menubar.js
@@ -463,8 +463,8 @@ class Menubar extends BaseMenu {
         if (key === "Space" || key === "Enter") {
           // Hitting Space or Enter:
           // - Activates menu item, causing the link to be activated.
-          preventEvent(event);
           if (this.currentMenuItem.isSubmenuItem) {
+            preventEvent(event);
             this.currentMenuItem.elements.childMenu.currentEvent = "keyboard";
             this.currentMenuItem.elements.toggle.open();
             // This ensures the the menu is _visually_ open before the child is focussed.
@@ -472,7 +472,7 @@ class Menubar extends BaseMenu {
               this.currentMenuItem.elements.childMenu.focusFirstChild();
             });
           } else {
-            preventEvent(event);
+            event.stopPropagation();
 
             this.currentMenuItem.dom.link.click();
           }

--- a/src/menubar.js
+++ b/src/menubar.js
@@ -460,21 +460,22 @@ class Menubar extends BaseMenu {
           }
         }
       } else {
-        if (
-          (key === "Space" || key === "Enter") &&
-          this.currentMenuItem.isSubmenuItem
-        ) {
+        if (key === "Space" || key === "Enter") {
           // Hitting Space or Enter:
           // - Activates menu item, causing the link to be activated.
           preventEvent(event);
-          this.currentMenuItem.elements.childMenu.currentEvent = "keyboard";
-          this.currentMenuItem.elements.toggle.open();
-          // This ensures the the menu is _visually_ open before the child is focussed.
-          requestAnimationFrame(() => {
-            this.currentMenuItem.elements.childMenu.focusFirstChild();
-          });
-        } else if (key === "Space") {
-          this.currentMenuItem.dom.link.click();
+          if (this.currentMenuItem.isSubmenuItem) {
+            this.currentMenuItem.elements.childMenu.currentEvent = "keyboard";
+            this.currentMenuItem.elements.toggle.open();
+            // This ensures the the menu is _visually_ open before the child is focussed.
+            requestAnimationFrame(() => {
+              this.currentMenuItem.elements.childMenu.focusFirstChild();
+            });
+          } else {
+            preventEvent(event);
+
+            this.currentMenuItem.dom.link.click();
+          }
         } else if (key === "Escape") {
           // Hitting Escape:
           // - Closes submenu.

--- a/src/menubar.js
+++ b/src/menubar.js
@@ -245,15 +245,8 @@ class Menubar extends BaseMenu {
         preventEvent(event);
       } else if (this.isTopLevel) {
         if (this.focusState === "self") {
-          const keys = [
-            "Space",
-            "Enter",
-            "ArrowRight",
-            "ArrowLeft",
-            "Home",
-            "End",
-          ];
-          const submenuKeys = ["ArrowDown", "ArrowUp"];
+          const keys = ["Space", "ArrowRight", "ArrowLeft", "Home", "End"];
+          const submenuKeys = ["Enter", "ArrowDown", "ArrowUp"];
           const controllerKeys = ["Escape"];
 
           if (keys.includes(key)) {
@@ -270,7 +263,6 @@ class Menubar extends BaseMenu {
       } else {
         const keys = [
           "Space",
-          "Enter",
           "Escape",
           "ArrowRight",
           "ArrowLeft",
@@ -279,8 +271,14 @@ class Menubar extends BaseMenu {
           "Home",
           "End",
         ];
+        const submenuKeys = ["Enter"];
 
         if (keys.includes(key)) {
+          preventEvent(event);
+        } else if (
+          this.currentMenuItem.isSubmenuItem &&
+          submenuKeys.includes(key)
+        ) {
           preventEvent(event);
         }
       }
@@ -343,20 +341,21 @@ class Menubar extends BaseMenu {
         this.focusNextChildWithCharacter(event.key);
       } else if (this.isTopLevel) {
         if (this.focusState === "self") {
-          if (key === "Space" || key === "Enter") {
+          if (
+            (key === "Space" || key === "Enter") &&
+            this.currentMenuItem.isSubmenuItem
+          ) {
             // Hitting Space or Enter:
             // - Opens submenu and moves focus to first item in the submenu.
-            if (this.currentMenuItem.isSubmenuItem) {
-              preventEvent(event);
-              this.currentMenuItem.elements.childMenu.currentEvent = "keyboard";
-              this.currentMenuItem.elements.toggle.open();
-              // This ensures the the menu is _visually_ open before the child is focussed.
-              requestAnimationFrame(() => {
-                this.currentMenuItem.elements.childMenu.focusFirstChild();
-              });
-            } else {
-              this.currentMenuItem.dom.link.click();
-            }
+            preventEvent(event);
+            this.currentMenuItem.elements.childMenu.currentEvent = "keyboard";
+            this.currentMenuItem.elements.toggle.open();
+            // This ensures the the menu is _visually_ open before the child is focussed.
+            requestAnimationFrame(() => {
+              this.currentMenuItem.elements.childMenu.focusFirstChild();
+            });
+          } else if (key === "Space") {
+            this.currentMenuItem.dom.link.click();
           } else if (key === "ArrowRight") {
             // Hitting the Right Arrow:
             // - Moves focus to the next item in the menubar.
@@ -461,20 +460,21 @@ class Menubar extends BaseMenu {
           }
         }
       } else {
-        if (key === "Space" || key === "Enter") {
+        if (
+          (key === "Space" || key === "Enter") &&
+          this.currentMenuItem.isSubmenuItem
+        ) {
           // Hitting Space or Enter:
           // - Activates menu item, causing the link to be activated.
-          if (this.currentMenuItem.isSubmenuItem) {
-            preventEvent(event);
-            this.currentMenuItem.elements.childMenu.currentEvent = "keyboard";
-            this.currentMenuItem.elements.toggle.open();
-            // This ensures the the menu is _visually_ open before the child is focussed.
-            requestAnimationFrame(() => {
-              this.currentMenuItem.elements.childMenu.focusFirstChild();
-            });
-          } else {
-            this.currentMenuItem.dom.link.click();
-          }
+          preventEvent(event);
+          this.currentMenuItem.elements.childMenu.currentEvent = "keyboard";
+          this.currentMenuItem.elements.toggle.open();
+          // This ensures the the menu is _visually_ open before the child is focussed.
+          requestAnimationFrame(() => {
+            this.currentMenuItem.elements.childMenu.focusFirstChild();
+          });
+        } else if (key === "Space") {
+          this.currentMenuItem.dom.link.click();
         } else if (key === "Escape") {
           // Hitting Escape:
           // - Closes submenu.
@@ -613,7 +613,7 @@ class Menubar extends BaseMenu {
         text = this.elements.menuItems[index].dom.item.textContent;
       }
 
-      // Remove spaces, make lowercase, and grab the first chracter of the string.
+      // Remove spaces, make lowercase, and grab the first character of the string.
       text = text.replace(/[\s]/g, "").toLowerCase().charAt(0);
 
       // Focus the child if the text matches, otherwise move on.

--- a/src/topLinkDisclosureMenu.js
+++ b/src/topLinkDisclosureMenu.js
@@ -590,7 +590,8 @@ class TopLinkDisclosureMenu extends BaseMenu {
 
       // Prevent default event actions if we're handling the keyup event.
       if (this.focusState === "self") {
-        const keys = ["Space", "Enter"];
+        const keys = ["Space"];
+        const submenuKeys = ["Enter"];
         const controllerKeys = ["Escape"];
         const parentKeys = ["Escape"];
         const optionalKeys = [
@@ -603,6 +604,11 @@ class TopLinkDisclosureMenu extends BaseMenu {
         ];
 
         if (keys.includes(key)) {
+          preventEvent(event);
+        } else if (
+          this.currentMenuItem.isSubmenuItem &&
+          submenuKeys.includes(key)
+        ) {
           preventEvent(event);
         } else if (this.optionalKeySupport && optionalKeys.includes(key)) {
           preventEvent(event);
@@ -646,19 +652,20 @@ class TopLinkDisclosureMenu extends BaseMenu {
       const key = keyPress(event);
 
       if (this.focusState === "self") {
-        if (key === "Space" || key === "Enter") {
+        if (
+          (key === "Space" || key === "Enter") &&
+          this.currentMenuItem.isSubmenuItem
+        ) {
           // Hitting Space or Enter:
           // - If focus is on a disclosure button, activates the button, which toggles the visibility of the dropdown.
-          if (this.currentMenuItem.isSubmenuItem) {
-            preventEvent(event);
-            if (this.currentMenuItem.elements.toggle.isOpen) {
-              this.currentMenuItem.elements.toggle.close();
-            } else {
-              this.currentMenuItem.elements.toggle.preview();
-            }
+          preventEvent(event);
+          if (this.currentMenuItem.elements.toggle.isOpen) {
+            this.currentMenuItem.elements.toggle.close();
           } else {
-            this.currentMenuItem.dom.link.click();
+            this.currentMenuItem.elements.toggle.preview();
           }
+        } else if (key === "Space") {
+          this.currentMenuItem.dom.link.click();
         } else if (key === "Escape") {
           // Hitting Escape
           // - If a dropdown is open, closes it.

--- a/src/treeview.js
+++ b/src/treeview.js
@@ -361,7 +361,6 @@ class Treeview extends BaseMenu {
       if (this.focusState === "self") {
         const keys = [
           "Space",
-          "Enter",
           "ArrowUp",
           "ArrowDown",
           "ArrowLeft",
@@ -369,7 +368,7 @@ class Treeview extends BaseMenu {
           "Home",
           "End",
         ];
-        const submenuKeys = ["ArrowRight"];
+        const submenuKeys = ["Enter", "ArrowRight"];
         const controllerKeys = ["Escape"];
 
         if (keys.includes(key)) {
@@ -428,21 +427,22 @@ class Treeview extends BaseMenu {
         this.elements.rootMenu.currentEvent = "character";
         this.focusNextNodeWithCharacter(event.key);
       } else if (this.focusState === "self") {
-        if (key === "Enter" || key === "Space") {
+        if (
+          (key === "Enter" || key === "Space") &&
+          this.currentMenuItem.isSubmenuItem
+        ) {
           // Hitting Space or Enter:
           // - Performs the default action (e.g. onclick event) for the focused node.
           // - If focus is on a closed node, opens the node; focus does not move.
           preventEvent(event);
 
-          if (this.currentMenuItem.isSubmenuItem) {
-            if (this.currentMenuItem.elements.toggle.isOpen) {
-              this.currentMenuItem.elements.toggle.close();
-            } else {
-              this.currentMenuItem.elements.toggle.preview();
-            }
+          if (this.currentMenuItem.elements.toggle.isOpen) {
+            this.currentMenuItem.elements.toggle.close();
           } else {
-            this.currentMenuItem.dom.link.click();
+            this.currentMenuItem.elements.toggle.preview();
           }
+        } else if (key === "Space") {
+          this.currentMenuItem.dom.link.click();
         } else if (key === "Escape") {
           if (
             this.isTopLevel &&


### PR DESCRIPTION
Unfortunately, we are still having issues with browser behavior after https://github.com/NickDJM/accessible-menu/pull/386. Handling the `Enter` key in `accessible-menu` seems to be unnecessary, because browsers already fire click events (assuming the target is a link or a button, but click would not have any effect otherwise, would it?).

As described in https://github.com/contao/contao/issues/8140, we're now having issues with Firefox. Let me try to paint a picture:
 - the click handler (`onclick=` in our case, but that shouldn't matter) triggers a `confirm` or `alert` dialog
 - the users uses the `Enter` key to confirm the dialog
 - Firefox now triggers the `keydown`/`keyup` event again (since a key was pressed), the target is still the menu item, therefore the click handler is fired again.

This only seems to be the case in Firefox, but not in Chrome or Safari. I found a thread from 2010 at https://stackoverflow.com/questions/24366151/firefox-stopping-propagation-of-enter-keypress-on-confirm-popup describing exactly this problem.

The best solution I could come up with was not to have `accessible-menu` handle the `Enter` key.

@NickDJM sorry for not fixing this in the first place. I hope you can follow-up with the other menu libraries like last time, I'm very much not familiar with them 🙈 
